### PR TITLE
Don't assume fn_kwargs is present in modelspec

### DIFF
--- a/nems/modelspec.py
+++ b/nems/modelspec.py
@@ -170,7 +170,8 @@ def evaluate(rec, modelspec, stop=None):
     d = copy.copy(rec)  # About 10x faster & fine if Signals are immutable
     for m in modelspec[:stop]:
         fn = _lookup_fn_at(m['fn'])
-        kwargs = {**m['fn_kwargs'], **m['phi']}  # Merges both dicts
+        fn_kwargs = m.get('fn_kwargs', {})
+        kwargs = {**fn_kwargs, **m['phi']}  # Merges both dicts
         new_signals = fn(rec=d, **kwargs)
         if type(new_signals) is not list:
             raise ValueError('Fn did not return list of signals: {}'.format(m))


### PR DESCRIPTION
Not all modules may require fn_kwargs (especially custom modules where
they already know the names of the inputs/outputs they want to use).