### PR TITLE
Fix some modulespec issues

### DIFF
--- a/nems/keywords.py
+++ b/nems/keywords.py
@@ -92,7 +92,7 @@ def defkey_fir(n_coefs, n_outputs):
     n_outputs : int
         Number of output channels.
     '''
-    name = 'fir{}x{}'.format(n_coefs, n_outputs)
+    name = 'fir{}x{}'.format(n_outputs, n_coefs)
     p_coefficients = {
         'mean': np.zeros((n_outputs, n_coefs)),
         'sd': np.ones((n_outputs, n_coefs)),
@@ -122,8 +122,9 @@ for n_inputs in (15, 18, 40):
         defkey_wcg(n_inputs, n_outputs)
 
 
-for n_coefs in (10, 15, 18):
-    defkey_fir(n_coefs, 1)
+for n_outputs in (1, 2, 3, 4):
+    for n_coefs in (10, 15, 18):
+        defkey_fir(n_coefs, n_outputs)
 
 
 defkey('lvl1',

--- a/nems/keywords.py
+++ b/nems/keywords.py
@@ -48,6 +48,8 @@ def defkey_wcg(n_inputs, n_outputs):
 
     Parameters
     ----------
+    n_inputs : int
+        Number of input channels.
     n_outputs : int
         Number of output channels.
 
@@ -71,12 +73,12 @@ def defkey_wcg(n_inputs, n_outputs):
 
     template = {
         'fn': 'nems.modules.weight_channels.gaussian',
-        'fn_kwargs': {'i': 'pred', 'o': 'pred'},
+        'fn_kwargs': {'i': 'pred', 'o': 'pred', 'n_chan_in': n_inputs},
         'fn_coefficients': 'nems.modules.weight_channels.gaussian_coefficients',
         'prior': {
             'mean': ('Normal', mean_prior_coefficients),
             'sd': ('HalfNormal', sd_prior_coefficients),
-        }
+        },
     }
     return defkey(name, template)
 

--- a/nems/modules/fir.py
+++ b/nems/modules/fir.py
@@ -18,6 +18,15 @@ def per_channel(x, coefficients):
     Private function used by fir_filter().
     '''
     result = []
+
+    # Make sure the number of input channels (x) match the number FIR filters
+    # provided (we have a separate filter for each channel). The `zip` function
+    # doesn't require the iterables to be the same length.
+    if len(x) != len(coefficients):
+        m = 'Dimension mismatch. Number of channels and filters must match. ' \
+            '{} channels provided for {} FIR filters.'
+        raise ValueError(m.format(len(x), len(coefficients)))
+
     for x, c in zip(x, coefficients):
         # It is slightly more "correct" to use lfilter than convolve at edges, but
         # but also about 25% slower (Measured on Intel Python Dist, using i5-4300M)

--- a/nems/modules/weight_channels.py
+++ b/nems/modules/weight_channels.py
@@ -37,7 +37,7 @@ def basic(rec, i, o, coefficients):
     return [rec[i].transform(fn, o)]
 
 
-def gaussian(rec, i, o, mean, sd):
+def gaussian(rec, i, o, n_chan_in, mean, sd):
     '''
     Parameters
     ----------
@@ -52,7 +52,6 @@ def gaussian(rec, i, o, mean, sd):
     sd : array-like
         Standard deviation of Gaussian channel weights
     '''
-    n_chan_in = rec[i].nchans
     coefficients = gaussian_coefficients(mean, sd, n_chan_in)
     fn = lambda x: coefficients @ x
     return [rec[i].transform(fn, o)]


### PR DESCRIPTION
This adds @svdavid's request to add `n_chan_in` to the Gaussian weight channels filter to facilitate plotting (and ensure we are being explicit about what the modulespec accepts). Also adds some missing keywords and fixes the FIR filter naming issue (before it was `fir18x1`, now it is `fir1x18`, so that the first number represents the number of *input* channels). 