### PR TITLE
added a simple manifest and changed the version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+# Include the readme since it's read by setup.py
+include README.md
+
+# Include the license file
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 NAME = 'NEMS'
 
-VERSION = 'pre-alpha'
+VERSION = '0.0.1a'
 
 with codecs.open('README.md', encoding='utf-8') as f:
     long_description = f.read()


### PR DESCRIPTION
I think that moving forward, it would be a good idea to abide by [semantic versioning](https://semver.org/). Note that the 0.y.z form indicates initial development, meaning that anything may change and the API is not considered stable. After the public API is "released" (1.0.0), the first number must increment after any backwards incompatible changes are made.

Closes #43 