### PR TITLE
built workaround for reading hdf5 files from inside tarballs

### DIFF
--- a/nems/recording.py
+++ b/nems/recording.py
@@ -127,54 +127,10 @@ class Recording:
     def load_targz(targz):
         if os.path.exists(targz):
             with open(targz, 'rb') as stream:
-                return Recording.load_from_targz_stream(stream)
+                return load_recording_from_targz_stream(stream)
         else:
             m = 'Not a .tar.gz file: {}'.format(targz)
             raise ValueError(m)
-
-    @staticmethod
-    def load_from_targz_stream(tgz_stream):
-        '''
-        Loads the recording object from the given .tar.gz stream, which
-        is expected to be a io.BytesIO object.
-        '''
-        streams = {}  # For holding file streams as we unpack
-        with tarfile.open(fileobj=tgz_stream, mode='r:gz') as t:
-            for member in t.getmembers():
-                if member.size == 0:  # Skip empty files
-                    continue
-                basename = os.path.basename(member.name)
-                # Now put it in a subdict so we can find it again
-                signame = str(basename.split('.')[0:2])
-                member_is_not_h5_datastream = True
-                if basename.endswith('epoch.csv'):
-                    keyname = 'epoch_stream'
-                elif basename.endswith('.csv'):
-                    keyname = 'data_stream'
-                elif basename.endswith('.h5'):
-                    keyname = 'data_stream'
-                    member_is_not_h5_datastream = False
-                elif basename.endswith('.json'):
-                    keyname = 'json_stream'
-                else:
-                    m = 'Unexpected file found in tar.gz: {} (size={})'.format(member.name, member.size)
-                    raise ValueError(m)
-                # Ensure that we can doubly nest the streams dict
-                if signame not in streams:
-                    streams[signame] = {}
-                # Read out a stringIO object for each file now while it's open
-                if member_is_not_h5_datastream:
-                    f = io.StringIO(t.extractfile(member).read().decode('utf-8'))
-                else:
-                    t.extract(member, '/tmp')
-                    f = '/tmp/' + member.name
-                streams[signame][keyname] = f
-
-        # Now that the streams are organized, convert them into signals
-        # log.debug({k: streams[k].keys() for k in streams})
-        signals = [load_signal_from_streams(**sg) for sg in streams.values()]
-        signals_dict = {s.name: s for s in signals}
-        return Recording(signals=signals_dict)
 
     @staticmethod
     def load_url(url):
@@ -194,7 +150,7 @@ class Recording:
             log.error(m)
             raise Exception(m)
         obj = io.BytesIO(r.raw.read()) # Not sure why I need this!
-        return Recording.load_from_targz_stream(obj)
+        return load_recording_from_targz_stream(obj)
 
     @staticmethod
     def load_from_arrays(arrays, rec_name, fs, sig_names=None,
@@ -794,7 +750,7 @@ def load_recording_from_url(url):
         log.error(m)
         raise Exception(m)
     obj = io.BytesIO(r.raw.read()) # Not sure why I need this!
-    return Recording.load_from_targz_stream(obj)
+    return load_recording_from_targz_stream(obj)
 
 def load_recording_from_arrays(arrays, rec_name, fs, sig_names=None,
                      signal_kwargs={}):


### PR DESCRIPTION
A limitation of the h5py library is that it can only read files from their location on disk rather than from streams. In the case where a .h5 file lives in a tarball, my workaround extracts and writes this file to `/tmp` and subsequently reads it. Let me know if there's a better place to be saving things.