### PR TITLE
Revamped fit_iteratively

### DIFF
--- a/nems/analysis/api.py
+++ b/nems/analysis/api.py
@@ -1,6 +1,6 @@
 from .fit_basic import (fit_basic, fit_random_subsets, fit_nfold,
                         fit_jackknifes, fit_subsets, fit_from_priors)
-from .fit_iteratively import fit_iteratively
+from .fit_iteratively import fit_iteratively, fit_module_sets
 from .test_prediction import generate_prediction, standard_correlation
 
 # Shorthand things here as well

--- a/nems/analysis/fit_iteratively.py
+++ b/nems/analysis/fit_iteratively.py
@@ -3,7 +3,10 @@ import time
 import logging
 import copy
 
+import numpy as np
+
 from nems.fitters.api import coordinate_descent
+from nems.analysis.fit_basic import fit_basic, basic_cost
 import nems.fitters.mappers
 import nems.metrics.api
 import nems.modelspec as ms
@@ -11,14 +14,138 @@ import nems.modelspec as ms
 log = logging.getLogger(__name__)
 
 
+def fit_module_sets(
+        data, modelspec,
+        cost_function=basic_cost, evaluator=ms.evaluate,
+        segmentor=nems.segmentors.use_all_data,
+        mapper=nems.fitters.mappers.simple_vector,
+        metric=lambda data: nems.metrics.api.nmse(data, 'pred', 'resp'),
+        fitter=coordinate_descent, fit_kwargs={}, metaname='fit_module_sets',
+        module_sets=None, invert=False, tolerance=1e-4, max_iter=1000
+        ):
+    '''
+    Required Arguments:
+     data          A recording object
+     modelspec     A modelspec object
+
+    Optional Arguments:
+     fitter        A function of (sigma, costfn) that tests various points,
+                   in fitspace (i.e. sigmas) using the cost function costfn,
+                   and hopefully returns a better sigma after some time.
+
+     module_sets   A nested list specifying which model indices should be fit.
+                   Overall iteration will occurr len(module_sets) many times.
+                   ex: [[0], [1, 3], [0, 1, 2, 3]]
+
+     invert        Boolean. Causes module_sets to specify the model indices
+                   that should *not* be fit.
+
+
+    Returns
+    A list containing a single modelspec, which has the best parameters found
+    by this fitter.
+    '''
+    if module_sets is None:
+        module_sets = [[i] for i in range(len(modelspec))]
+    fit_kwargs.update({'tolerance': tolerance, 'max_iter': max_iter})
+
+    # Ensure that phi exists for all modules; choose prior mean if not found
+    for i, m in enumerate(modelspec):
+        if not m.get('phi'):
+            log.debug('Phi not found for module, using mean of prior: {}'
+                      .format(m))
+            m = nems.priors.set_mean_phi([m])[0]  # Inits phi for 1 module
+            modelspec[i] = m
+
+    if invert:
+        module_sets = _invert_subsets(modelspec, module_sets)
+
+    ms.fit_mode_on(modelspec)
+    start_time = time.time()
+
+    log.info("Fitting all subsets with tolerance: %.2E", tolerance)
+    for subset in module_sets:
+        improved_modelspec = _module_set_loop(
+                subset, data, modelspec, cost_function, fitter,
+                mapper, segmentor, evaluator, metric, fit_kwargs
+                )
+
+    elapsed_time = (time.time() - start_time)
+
+    # TODO: Should this maybe be moved to a higher level
+    # so it applies to ALL the fittters?
+    ms.fit_mode_off(improved_modelspec)
+    ms.set_modelspec_metadata(improved_modelspec, 'fitter', metaname)
+    ms.set_modelspec_metadata(improved_modelspec, 'fit_time', elapsed_time)
+    results = [copy.deepcopy(improved_modelspec)]
+
+    return results
+
+
+def _invert_subsets(modelspec, module_sets):
+    inverted = []
+    for subset in module_sets:
+        subset_inverted = [
+                None if i in subset else i
+                for i, in enumerate(modelspec)
+                ]
+        inverted.append([i for i in subset_inverted if i is not None])
+        log.debug("Inverted subset: %s\n", subset)
+
+    return inverted
+
+
+def _module_set_loop(subset, data, modelspec, cost_function, fitter,
+                     mapper, segmentor, evaluator, metric, fit_kwargs):
+        log.info("Fitting subset: %s", subset)
+        mods = [m['fn'] for i, m in enumerate(modelspec) if i in subset]
+        log.info("%s\n", mods)
+
+        # remove hold_outs from modelspec
+        frozen_phi = []
+        for i, m in enumerate(modelspec):
+            if i not in subset:
+                frozen_phi.append(m['phi'])
+                m['fn_kwargs'].update(m['phi'])
+                m['phi'] = {}
+            else:
+                frozen_phi.append(None)
+
+        log.debug("Modelspec after freeze: %s", modelspec)
+
+        packer, unpacker = mapper(modelspec)
+        #cost_function.counter = 0
+        cost_function.error = None
+        cost_fn = partial(cost_function,
+                          unpacker=unpacker, modelspec=modelspec,
+                          data=data, segmentor=segmentor, evaluator=evaluator,
+                          metric=metric)
+        sigma = packer(modelspec)
+
+        improved_sigma = fitter(sigma, cost_fn, **fit_kwargs)
+        improved_modelspec = unpacker(improved_sigma)
+
+        for i, m in enumerate(improved_modelspec):
+            if i not in subset:
+                m['phi'] = frozen_phi[i]
+                for k in frozen_phi[i]:
+                    m['fn_kwargs'].pop(k)
+
+        log.debug("Modelspec after unfreeze: %s", improved_modelspec)
+
+        return improved_modelspec
+
+
 def fit_iteratively(
         data, modelspec,
-        fitter=coordinate_descent,
+        cost_function=basic_cost,
+        fitter=coordinate_descent, evaluator=ms.evaluate,
         segmentor=nems.segmentors.use_all_data,
         mapper=nems.fitters.mappers.simple_vector,
         metric=lambda data: nems.metrics.api.nmse(data, 'pred', 'resp'),
         metaname='fit_basic', fit_kwargs={},
-        module_sets=None, invert=False, tolerances=None, max_iter=100
+        module_sets=None, invert=False, tolerances=None, tol_iter=100,
+        fit_iter=20,
         ):
     '''
     Required Arguments:
@@ -55,7 +182,7 @@ def fit_iteratively(
         tolerances = [1e-6]
 
     start_time = time.time()
-
+    ms.fit_mode_on(modelspec)
     # Ensure that phi exists for all modules; choose prior mean if not found
     for i, m in enumerate(modelspec):
         if not m.get('phi'):
@@ -64,101 +191,33 @@ def fit_iteratively(
             m = nems.priors.set_mean_phi([m])[0]  # Inits phi for 1 module
             modelspec[i] = m
 
-    # Create the mapper object that translates to and from modelspecs.
-    # It has two methods that, when defined as mathematical functions, are:
-    #    .pack(modelspec) -> fitspace_point
-    #    .unpack(fitspace_point) -> modelspec
-    packer, unpacker = mapper(modelspec)
-
-    # A function to evaluate the modelspec on the data
-    evaluator = ms.evaluate
-
-    # get initial sigma value representing some point in the fit space
-    sigma = packer(modelspec)
-
+    error = np.inf
     for tol in tolerances:
         log.info("Fitting all subsets with tolerance: %.2E", tol)
-        for subset in module_sets:
-            log.info("Fitting subset: %s", subset)
-            mods = [m['fn'] for i, m in enumerate(modelspec) if i in subset]
-            log.info("%s\n", mods)
-            if invert:
-                # invert the indices
-                subset_inverted = [
-                        None if i in subset else i
-                        for i, in enumerate(modelspec)
-                        ]
-                subset = [i for i in subset_inverted if i is not None]
-                log.debug("Inverted subset: %s\n", subset)
+        fit_kwargs.update({'tolerance': tol, 'max_iter': fit_iter})
+        error_reduction = np.inf
+        i = 0
 
-            # remove hold_outs from modelspec
-            held_out = []
-            subtracted_modelspec = []
-            for i, m in enumerate(modelspec):
-                if i in subset:
-                    held_out.append(None)
-                    subtracted_modelspec.append(m)
-                else:
-                    held_out.append(m)
-            log.debug("\n\nheld_out subset was: %s\n\nsubtracted_modelspec: %s",
-                      held_out, subtracted_modelspec)
-
-            def cost_function(sigma, unpacker, modelspec, data,
-                              evaluator, metric, held_out):
-                updated_spec = unpacker(sigma)
-                # The segmentor takes a subset of the data for fitting each step
-                # Intended use is for CV or random selection of chunks of the data
-                data_subset = segmentor(data)
-
-                # Put hold_out back in before evaluating
-                recombined_spec = []
-                j = 0
-                for i, m in enumerate(held_out):
-                    if m is None:
-                        recombined_spec.append(updated_spec[j])
-                        j += 1
-                    else:
-                        recombined_spec.append(m)
-
-                updated_data_subset = evaluator(data_subset, recombined_spec)
-                error = metric(updated_data_subset)
-                log.debug("inside cost function, current error: %.06f", error)
-                log.debug("\ncurrent sigma: %s", sigma)
-
-                cost_function.counter += 1
-                if cost_function.counter % 1000 == 0:
-                    log.info('Eval #%d. E=%.06f', cost_function.counter, error)
-                    log.debug("\n\nrecombined_spec was: %s", recombined_spec)
-
-                return error
-
-            cost_function.counter = 0
-
-            # Freeze everything but sigma, since that's all the fitter should be
-            # updating.
-            cost_fn = partial(cost_function,
-                              unpacker=unpacker, modelspec=subtracted_modelspec,
-                              data=data, evaluator=evaluator,
-                              metric=metric, held_out=held_out)
-
-            # do fit
-            improved_sigma = fitter(sigma, cost_fn, tolerance=tol,
-                                    max_iter=max_iter, **fit_kwargs)
-            improved_modelspec = unpacker(improved_sigma)
-
-            recombined_modelspec = [
-                    phi if phi is not None else held_out[i]
-                    for i, phi in enumerate(improved_modelspec)
-                    ]
-            log.debug("\n\nsubset: %s\nrecombined_modelspec: %s",
-                      subset, recombined_modelspec)
+        while (error_reduction >= tol) and (i < tol_iter):
+            for subset in module_sets:
+                improved_modelspec = _module_set_loop(
+                        subset, data, modelspec, cost_function, fitter,
+                        mapper, segmentor, evaluator, metric, fit_kwargs
+                        )
+                new_error = cost_function.error
+                error_reduction = error-new_error
+                error = new_error
+                log.debug("Error reduction was: %.6E", error_reduction)
+            i += 1
 
     elapsed_time = (time.time() - start_time)
 
     # TODO: Should this maybe be moved to a higher level
     # so it applies to ALL the fittters?
-    ms.set_modelspec_metadata(recombined_modelspec, 'fitter', metaname)
-    ms.set_modelspec_metadata(recombined_modelspec, 'fit_time', elapsed_time)
-    results = [copy.deepcopy(recombined_modelspec)]
+    ms.fit_mode_off(improved_modelspec)
+    ms.set_modelspec_metadata(improved_modelspec, 'fitter', metaname)
+    ms.set_modelspec_metadata(improved_modelspec, 'fit_time', elapsed_time)
+    results = [copy.deepcopy(improved_modelspec)]
 
     return results
+

--- a/nems/fitters/fitter.py
+++ b/nems/fitters/fitter.py
@@ -28,8 +28,6 @@ def dummy_fitter(sigma, cost_fn, bounds=None, fixed=None):
     return sigma
 
 
-# HACK: **kwargs doesn't actually get used, it's just there to prevent
-#       error when analyses try to pass in options dict for other fitters.
 def coordinate_descent(sigma, cost_fn, step_size=0.1, step_change=0.5,
                        step_min=1e-5, tolerance=1e-2, max_iter=100, **kwargs):
 
@@ -67,9 +65,9 @@ def coordinate_descent(sigma, cost_fn, step_size=0.1, step_change=0.5,
 
         # If j is 1, shift was negative, otherwise it was 0 for positive.
         if j_sign == 1:
-            sigma[i_param] = this_sigma[i_param] = sigma[i_param] - step_size 
+            sigma[i_param] = this_sigma[i_param] = sigma[i_param] - step_size
         else:
-            sigma[i_param] = this_sigma[i_param] = sigma[i_param] + step_size 
+            sigma[i_param] = this_sigma[i_param] = sigma[i_param] + step_size
 
         update_stepinfo(err=err)
 

--- a/nems/xform_helper.py
+++ b/nems/xform_helper.py
@@ -155,32 +155,39 @@ def generate_fitter_xfspec(fitter, fitter_kwargs=None):
         xfspec.append(['nems.xforms.fit_basic', {}])
         xfspec.append(['nems.xforms.predict',    {}])
 
-    elif fitter == "fititer01":
-        '''fit_iteratively with scipy_minimize'''
-        kw_list = ['module_sets', 'tolerances', 'invert', 'max_iter']
-        defaults = [None, None, False, 100]
-        module_sets, tolerances, invert, max_iter = \
+    elif fitter == "fitsubs":
+        '''fit_subsets with scipy_minimize'''
+        kw_list = ['module_sets', 'tolerance', 'fitter']
+        defaults = [None, 1e-4, coordinate_descent]
+        module_sets, tolerance, my_fitter = \
             _get_my_kwargs(fitter_kwargs, kw_list, defaults)
         xfspec.append([
-                'nems.xforms.fit_iteratively',
-                {'module_sets':module_sets, 'tolerances': tolerances,
-                 'invert': invert, 'max_iter': max_iter,
-                 'fitter': scipy_minimize}
+                'nems.xforms.fit_module_sets',
+                {'module_sets': module_sets, 'fitter': scipy_minimize,
+                 'tolerance': tolerance}
                 ])
         xfspec.append(['nems.xforms.predict', {}])
 
-    elif fitter == "fititer02":
-        '''fit_iteratively with coordinate_descent'''
-        kw_list = ['module_sets', 'tolerances', 'invert', 'max_iter']
-        defaults = [None, None, False, 100]
-        module_sets, tolerances, invert, max_iter = \
+    elif fitter.startswith("fitsubs"):
+        xfspec.append(_parse_fitsubs(fitter))
+        xfspec.append(['nems.xforms.predict', {}])
+
+    elif fitter == "fititer":
+        kw_list = ['module_sets', 'tolerances', 'tol_iter', 'fit_iter',
+                   'fitter']
+        defaults = [None, None, 100, 20, coordinate_descent]
+        module_sets, tolerances, tol_iter, fit_iter, my_fitter = \
             _get_my_kwargs(fitter_kwargs, kw_list, defaults)
         xfspec.append([
                 'nems.xforms.fit_iteratively',
-                {'module_sets':module_sets, 'tolerances': tolerances,
-                 'invert': invert, 'max_iter': max_iter,
-                 'fitter': coordinate_descent}
+                {'module_sets': module_sets, 'fitter': my_fitter,
+                 'tolerances': tolerances, 'tol_iter': tol_iter,
+                 'fit_iter': fit_iter}
                 ])
+        xfspec.append(['nems.xforms.predict', {}])
+
+    elif fitter.startswith("fititer"):
+        xfspec.append(_parse_fititer(fitter))
         xfspec.append(['nems.xforms.predict', {}])
 
     else:
@@ -192,14 +199,114 @@ def generate_fitter_xfspec(fitter, fitter_kwargs=None):
 def _get_my_kwargs(kwargs, kw_list, defaults):
     '''Fetch value of kwarg if given, otherwise corresponding default'''
     my_kwargs = []
-    for i, kw in enumerate(kw_list):
+    for kw, default in zip(kw_list, defaults):
         if kwargs is None:
-            a = defaults[i]
+            a = default
         else:
-            a = kwargs.pop(kw, defaults[i])
+            a = kwargs.pop(kw, default)
         my_kwargs.append(a)
     return my_kwargs
 
+
+def _parse_fititer(fit_keyword):
+    # ex: fititer01-T4-T6-S0x1-S0x1x2x3-ti50-fi20
+    # fitter: scipy_minimize; tolerances: [1e-4, 1e-6]; s
+    # subsets: [[0,1], [0,1,2,3]]; tol_iter: 50; fit_iter: 20;
+    # Note that order does not matter except for starting with
+    # 'fititer<some number>' to specify the analysis and fit algorithm
+    chunks = fit_keyword.split('-')
+
+    fit = chunks[0]
+    if fit.endswith('01'):
+        fitter = scipy_minimize
+    elif fit.endswith('02'):
+        fitter = coordinate_descent
+    else:
+        fitter = coordinate_descent
+        log.warn("Unrecognized or unspecified fit algorithm for fititer: %s\n"
+                 "Using default instead: %s", fit[7:], fitter)
+
+    tolerances = []
+    module_sets = []
+    fit_iter = None
+    tol_iter = None
+
+    for c in chunks[1:]:
+        if c.startswith('ti'):
+            tol_iter = int(c[2:])
+        elif c.startswith('fi'):
+            fit_iter = int(c[2:])
+        elif c.startswith('T'):
+            power = int(c[1:])*-1
+            tol = 10**(power)
+            tolerances.append(tol)
+        elif c.startswith('S'):
+            indices = [int(i) for i in c[1:].split('x')]
+            module_sets.append(indices)
+        else:
+            log.warning(
+                    "Unrecognized segment in fititer keyword: %s\n"
+                    "Correct syntax is:\n"
+                    "fititer<fitter>-S<i>x<j>...-T<tolpower>...ti<tol_iter>"
+                    "-fi<fit_iter>", c
+                    )
+
+
+    if not tolerances:
+        tolerances = None
+    if not module_sets:
+        module_sets = None
+
+    return ['nems.xforms.fit_iteratively',
+            {'module_sets': module_sets, 'fitter': fitter,
+             'tolerances': tolerances, 'tol_iter': tol_iter,
+             'fit_iter': fit_iter}]
+
+
+def _parse_fitsubs(fit_keyword):
+    # ex: fitsubs02-S0x1-S0x1x2x3-it1000-T6
+    # fitter: scipy_minimize; subsets: [[0,1], [0,1,2,3]];
+    # max_iter: 1000;
+    # Note that order does not matter except for starting with
+    # 'fitsubs<some number>' to specify the analysis and fit algorithm
+    chunks = fit_keyword.split('-')
+
+    fit = chunks[0]
+    if fit.endswith('01'):
+        fitter = scipy_minimize
+    elif fit.endswith('02'):
+        fitter = coordinate_descent
+    else:
+        fitter = coordinate_descent
+        log.warn("Unrecognized or unspecified fit algorithm for fitsubs: %s\n"
+                 "Using default instead: %s", fit[7:], fitter)
+
+    module_sets = []
+    max_iter = None
+    tolerance = None
+
+    for c in chunks[1:]:
+        if c.startswith('it'):
+            max_iter = int(c[2:])
+        elif c.startswith('S'):
+            indices = [int(i) for i in c[1:].split('x')]
+            module_sets.append(indices)
+        elif c.startswith('T'):
+            power = int(c[1:])*-1
+            tolerance = 10**(power)
+        else:
+            log.warning(
+                    "Unrecognized segment in fitsubs keyword: %s\n"
+                    "Correct syntax is:\n"
+                    "fitsubs<fitter>-S<i>x<j>...-T<tolpower>-it<max_iter>", c
+                    )
+
+    if not module_sets:
+        module_sets = None
+
+    return ['nems.xforms.fit_iteratively',
+            {'module_sets': module_sets, 'fitter': fitter,
+             'tolerance': tolerance, 'max_iter': max_iter}]
 
 # TODO: take baphy out of names and docs if we're keeping these here.
 #       (fit and load)

--- a/scripts/test_fit_iter_xforms.py
+++ b/scripts/test_fit_iter_xforms.py
@@ -1,21 +1,18 @@
 from nems.xform_helper import fit_model_xforms
 
 recording_uri = '/auto/users/jacob/nems/recordings/TAR010c-18-1.tar.gz'
-modelname = 'ozgf100ch18_wcg18x1_fir1x15_lvl1_dexp1_fititer01'
+modelname = 'ozgf100ch18_wcg18x1_fir1x15_lvl1_dexp1_'
+fitter = 'fititer01-T4-T6-S0x1-S0x1x2x3-ti20-fi20'
+modelname += fitter
 
-# TODO: This kind of does the same thing as keywords, so maybe figure out
-#       a way to use those instead? But module_sets are so variable it
-#       seems clunky to need a diff kw for each one, esp. since the setup
-#       of module_sets depends heavily on the other parts of the model.
+# Above keyword does the same thing as:
+# (see _parse_fititer in xform_helper)
+#fitter_kwargs = {
+#        'module_sets': [[0, 1], [0, 1, 2, 3]],
+#        'tolerances': [1e-4, 1e-6],
+#        'tol_iter': 20,
+#        'fit_iter': 20,
+#        'fitter': coordinate_descent,
+#        }
 
-# Could try to parse something like fititer-T4-T6-S0x1-S0x1x2x3
-# to mean Tolerances: [1e-4, 1e-6]; Subsets: [[0,1], [0,1,2,3]],
-# but at that point just passing the kwargs seems simpler.
-fitter_kwargs = {
-        'module_sets': [[0, 1], [0, 1, 2, 3]],
-        'tolerances':  [1e-4, 1e-6, 1e-8],
-        'invert': False,
-        'max_iter': 50,
-        }
-
-fit_model_xforms(recording_uri, modelname, fitter_kwargs=fitter_kwargs)
+fit_model_xforms(recording_uri, modelname)


### PR DESCRIPTION
Split into fit_module_sets and fit_iteratively.
fit_module_sets uses the previous behavior with some
unnecessary checks/loops removed.
fit_iteratively has added the outer tolerance loop
and split iters max_iter argument into 'tol_iter'
to control the max number of total loops per tolerance
level and 'fit_iter' to control the max number of
fitter steps between tolerance checks.

Pulled fit_basic's cost_function into a separate
function named 'basic_cost' in the same module
so that fit_module_sets and fit_iteratively can
use it (as well as future analyses).

Created keyword parsers for fit_module_sets and
fit_iteratively so that using fitter_kwargs
is not necessary.