### PR TITLE
new functions to save model performance on per-jackknife basis

### DIFF
--- a/nems/analysis/api.py
+++ b/nems/analysis/api.py
@@ -1,6 +1,6 @@
 from .fit_basic import (fit_basic, fit_random_subsets, fit_nfold,
                         fit_jackknifes, fit_subsets, fit_from_priors)
 from .fit_iteratively import fit_iteratively
-from .test_prediction import generate_prediction, standard_correlation
+from .test_prediction import generate_prediction, standard_correlation, generate_prediction_sets, standard_correlation_by_set
 
 # Shorthand things here as well

--- a/nems/analysis/test_prediction.py
+++ b/nems/analysis/test_prediction.py
@@ -42,3 +42,37 @@ def standard_correlation(est,val,modelspecs):
 
     return modelspecs
 
+
+def generate_prediction_sets(est,val,modelspecs):
+    if type(val) is list:
+        # ie, if jackknifing
+        new_est = [ms.evaluate(d, m) for m,d in zip(modelspecs,est)]
+        new_val = [ms.evaluate(d, m) for m,d in zip(modelspecs,val)]
+    else:
+        print('val and est must be lists')
+    
+    return new_est, new_val
+        
+def standard_correlation_by_set(est,val,modelspecs):
+
+    # Compute scores for validation data
+    r_test = [nmet.corrcoef(p, 'pred', 'resp') for p in val]
+    mse_test = [nmet.nmse(p, 'pred', 'resp') for p in val]
+    ll_test = [nmet.likelihood_poisson(p, 'pred', 'resp') for p in val]
+
+    # Repeat for est data.
+    r_fit = [nmet.corrcoef(p, 'pred', 'resp') for p in est]
+    mse_fit = [nmet.nmse(p, 'pred', 'resp') for p in est]
+    ll_fit = [nmet.likelihood_poisson(p, 'pred', 'resp') for p in est]
+    
+    
+    for i in range(len(modelspecs)):
+        modelspecs[i][0]['meta']['r_test'] = r_test[i]
+        modelspecs[i][0]['meta']['mse_test'] = mse_test[i]
+        modelspecs[i][0]['meta']['ll_test'] = ll_test[i]
+        
+        modelspecs[i][0]['meta']['r_fit'] = r_fit[i]
+        modelspecs[i][0]['meta']['mse_fit'] = mse_fit[i]
+        modelspecs[i][0]['meta']['ll_fit'] = ll_fit[i]
+        
+    return modelspecs 


### PR DESCRIPTION
Can I add these functions to test_prediction.py? Identical to the functions already in place, but allows you to save fit metrics on a per val set basis rather than using the entire dataset. I'm open to other ways of doing this...