### PR TITLE
basic logistic_sigmoid implementation

### DIFF
--- a/nems/distributions/api.py
+++ b/nems/distributions/api.py
@@ -3,3 +3,4 @@ from .half_normal import HalfNormal
 from .uniform import Uniform
 from .beta import Beta
 from .gamma import Gamma
+from .exponential import Exponential

--- a/nems/distributions/exponential.py
+++ b/nems/distributions/exponential.py
@@ -1,0 +1,22 @@
+from scipy import stats
+import numpy as np
+
+from .distribution import Distribution
+
+class Exponential(Distribution):
+    '''
+    Exponential Prior
+    
+    Parameters
+    ----------
+    beta : scalar or ndarray
+        Scale of distribution.
+        Also determines mean=beta and std=beta
+    '''
+    
+    def __init__(self, beta):
+        self._beta = self._mean = self._sd = np.asarray(beta)
+        self.distribution = stats.expon(scale=beta)
+
+    def __repr__(self):
+        return 'Exponential(β={})'.format(beta)

--- a/nems/distributions/exponential.py
+++ b/nems/distributions/exponential.py
@@ -6,14 +6,14 @@ from .distribution import Distribution
 class Exponential(Distribution):
     '''
     Exponential Prior
-    
+
     Parameters
     ----------
     beta : scalar or ndarray
         Scale of distribution.
         Also determines mean=beta and std=beta
     '''
-    
+
     def __init__(self, beta):
         self._beta = self._mean = self._sd = np.asarray(beta)
         self.distribution = stats.expon(scale=beta)

--- a/nems/fitters/fitter.py
+++ b/nems/fitters/fitter.py
@@ -81,7 +81,7 @@ def coordinate_descent(sigma, cost_fn, step_size=0.1, step_change=0.5,
 
 
 def scipy_minimize(sigma, cost_fn, tolerance=None, max_iter=None,
-                   method='L-BFGS-B', options={'maxiter': 1000, 'ftol': 1e-7}):
+                   method='L-BFGS-B', options={}):
     """
     Wrapper for scipy.optimize.minimize to normalize format with
     NEMS fitters.
@@ -94,12 +94,16 @@ def scipy_minimize(sigma, cost_fn, tolerance=None, max_iter=None,
     TODO: Pull in code from scipy.py in docs/planning to
           expose more output during iteration.
     """
+    # Convert NEMS' tolerance and max_iter kwargs to scipy options,
+    # but also allow passing options directly
     if tolerance is not None:
         if 'ftol' in options:
             log.warn("Both <tolerance> and <options: ftol> provided for\n"
                      "scipy_minimize, using <tolerance> by default: %.2E",
                      tolerance)
         options['ftol'] = tolerance
+    elif tolerance is None and 'ftol' not in options:
+        options['ftol'] = 1e-7
 
     if max_iter is not None:
         if 'maxiter' in options:
@@ -107,6 +111,8 @@ def scipy_minimize(sigma, cost_fn, tolerance=None, max_iter=None,
                      "scipy_minimize, using <max_iter> by default: %d",
                      max_iter)
         options['maxiter'] = max_iter
+    elif max_iter is None and 'maxiter' not in options:
+        options['maxiter'] = 1000
 
     result = scp.optimize.minimize(cost_fn, sigma, method=method,
                                    options=options)

--- a/nems/keywords.py
+++ b/nems/keywords.py
@@ -315,10 +315,10 @@ defkey('logsig1',
        {'fn': 'nems.modules.nonlinearity.logistic_sigmoid',
         'fn_kwargs': {'i': 'pred',
                       'o': 'pred'},
-        'prior': {'base': ('Normal', {'mean': [0], 'sd': [1]}),
-                  'amplitude': ('Normal', {'mean': [0.2], 'sd': [1]}),
-                  'shift': ('Normal', {'mean': [1], 'sd': [1]}),
-                  'kappa': ('Normal', {'mean': [-2], 'sd': [1]})}})
+        'prior': {'base': ('Exponential', {'beta': [0.1]}),
+                  'amplitude': ('Exponential', {'beta': [2.0]}),
+                  'shift': ('Normal', {'mean': [1.0], 'sd': [1.0]}),
+                  'kappa': ('Exponential', {'beta': [0.1]})}})
 
 defkey('tanh1',
        {'fn': 'nems.modules.nonlinearity.tanh',

--- a/nems/keywords.py
+++ b/nems/keywords.py
@@ -311,6 +311,7 @@ defkey('qsig1',
                   'shift': ('Normal', {'mean': [1.5], 'sd': [1.0]}),
                   'kappa': ('Normal', {'mean': [0.1], 'sd': [0.1]})}})
 
+# NOTE: Typically overwritten by nems.initializers.init_logsig
 defkey('logsig1',
        {'fn': 'nems.modules.nonlinearity.logistic_sigmoid',
         'fn_kwargs': {'i': 'pred',

--- a/nems/metrics/corrcoef.py
+++ b/nems/metrics/corrcoef.py
@@ -156,15 +156,8 @@ def _r_single(X, N=100):
 
 def r_ceiling(result, fullrec, pred_name='pred', resp_name='resp', N=100):
     """
-<<<<<<< HEAD
-    Assume X is trials X time raster
-
-    test data from SPN recording
-    X=rec['resp'].extract_epoch('STIM_BNB+si464+si1889')
-=======
     Compute noise-corrected correlation coefficient based on single-trial
     correlations in the actual response.
->>>>>>> origin/master
     """
     epoch_regex = '^STIM_'
     epochs_to_extract = ep.epoch_names_matching(result[resp_name].epochs,

--- a/nems/metrics/corrcoef.py
+++ b/nems/metrics/corrcoef.py
@@ -41,7 +41,7 @@ def corrcoef(result, pred_name='pred', resp_name='resp'):
     resp = result[resp_name].as_continuous()
     if pred.shape[0] > 1:
         raise ValueError("multi-channel signals not supported yet.")
-        
+
     ff = np.isfinite(pred) & np.isfinite(resp)
     if np.sum(ff) == 0:
         return 0
@@ -57,48 +57,48 @@ def r_floor(result, pred_name='pred', resp_name='resp'):
     # if running validation test, also measure r_floor
     X1 = result[pred_name].as_continuous()
     X2 = result[resp_name].as_continuous()
-    
+
     if X1.shape[0] > 1:
         raise ValueError("multi-channel signals not supported yet.")
-    
+
     # remove all nans from pred and resp
     ff = np.isfinite(X1) & np.isfinite(X2)
     X1=X1[ff]
     X2=X2[ff]
-    
+
     # figure out how many samples to use in each shuffle
     if len(X1)>500:
         n=500
     else:
         n=len(X1)
-        
+
     # compute cc for 1000 shuffles
     rf = np.zeros([1000, 1])
     for rr in range(0, len(rf)):
         n1 = (np.random.rand(n) * len(X1)).astype(int)
         n2 = (np.random.rand(n) * len(X2)).astype(int)
         rf[rr] = np.corrcoef(X1[n1], X2[n2])[0, 1]
-        
+
     rf = np.sort(rf[np.isfinite(rf)], 0)
     if len(rf):
         r_floor = rf[np.int(len(rf) * 0.95)]
     else:
         r_floor = 0
-        
+
     return r_floor
 
 
 def _r_single(X, N=100):
     """
     Assume X is trials X time raster
-    
+
     test data from SPN recording
     X=rec['resp'].extract_epoch('STIM_BNB+si464+si1889')
     """
-    
+
     if X.shape[1] > 1:
         raise ValueError("multi-channel signals not supported yet.")
-    
+
     repcount=X.shape[0]
     if repcount <= 1:
         log.info('repcount<=1, rnorm=0')
@@ -109,10 +109,10 @@ def _r_single(X, N=100):
     for p1 in range(repcount):
         for p2 in range (p1+1, repcount):
             pairs.append([p1,p2])
-        
+
     if paircount < N:
         N = paircount
-            
+
     if N == 1:
         # only two repeats, break up data in time to get a better
         # estimate of single-trial correlations
@@ -126,75 +126,75 @@ def _r_single(X, N=100):
         #         rac(nn)=xcov(resp(tt,1),resp(tt,2),0,'coeff');
         #     end
         # end
-    
+
     else:
-    
+
         rac=np.zeros(N)
         sidx = np.argsort(np.random.rand(paircount))
         for nn in range(N):
             X1 = X[pairs[sidx[nn]][0],0,:]
             X2 = X[pairs[sidx[nn]][1],0,:]
-            
+
             # remove all nans from pred and resp
             ff = np.isfinite(X1) & np.isfinite(X2)
             X1=X1[ff]
             X2=X2[ff]
-            
+
             rac[nn] = np.corrcoef(X1, X2)[0, 1]
 
     rac=np.mean(rac);
     if rac<0.05:
         rac = 0.05
-    
+
     return rac
 
 
 def r_ceiling(result, fullrec, pred_name='pred', resp_name='resp', N=100):
     """
     Assume X is trials X time raster
-    
+
     test data from SPN recording
     X=rec['resp'].extract_epoch('STIM_BNB+si464+si1889')
     """
     epoch_regex = '^STIM_'
     epochs_to_extract = ep.epoch_names_matching(result[pred_name].epochs, epoch_regex)
     folded_pred = result[pred_name].extract_epochs(epochs_to_extract)
-    
+
     rnorm_c = 0
     n = 0
     resp = fullrec[resp_name].rasterize()
-    
+
     for k, d in folded_pred.items():
         if np.sum(np.isfinite(d)) > 0:
-            
-            X = resp.extract_epoch(k)            
+
+            X = resp.extract_epoch(k)
             rac = _r_single(X, N)
 
             # print(k)
             # print(rac)
-            
-            if rac > 0:    
+
+            if rac > 0:
                 repcount = X.shape[0]
                 rs = np.zeros(repcount)
                 for nn in range(repcount):
                     X1 = X[nn,0,:]
                     X2 = d[0,0,:]
-                    
+
                     # remove all nans from pred and resp
                     ff = np.isfinite(X1) & np.isfinite(X2)
                     X1=X1[ff]
                     X2=X2[ff]
-                    
+
                     rs[nn] = np.corrcoef(X1, X2)[0, 1]
-                    
+
                 rs=np.mean(rs)
-                
+
                 rnorm_c += (rs / np.sqrt(rac)) * X1.shape[-1]
                 n += X1.shape[-1]
-                
+
     # weighted average based on number of samples in each epoch
     rnorm = rnorm_c / n
-    
+
     return rnorm
-                
-    
+
+

--- a/nems/recording.py
+++ b/nems/recording.py
@@ -13,8 +13,8 @@ import shutil
 
 from nems.uri import local_uri, http_uri, targz_uri
 import nems.epoch as ep
-from nems.signal import SignalBase, merge_selections, list_signals, \
-                        load_signal, load_signal_from_streams
+from nems.signal import SignalBase, RasterizedSignal, merge_selections, \
+                        list_signals, load_signal, load_signal_from_streams
 
 log = logging.getLogger(__name__)
 

--- a/nems/xforms.py
+++ b/nems/xforms.py
@@ -287,6 +287,11 @@ def fit_basic_init(modelspecs, est, IsReload=False, **context):
                         for modelspec in modelspecs]
                 break
 
+            elif 'logistic_sigmoid' in m['fn']:
+                modelspecs = [nems.initializers.init_logsig(est, modelspec)
+                              for modelspec in modelspecs]
+                break
+
     return {'modelspecs': modelspecs}
 
 


### PR DESCRIPTION
Added Exponential distribution for use by logistic_sigmoid priors,
Edited default priors in logsig1 keyword definition to reflect suggestions in Rabinowitz et al.,
Added nems.initializers.init_logsig to set priors to reasonable distrbutions based on stim and resp,
also based on info in Rabinowitz et al.
Added call to init_logsig in fit_basic_init when logsig keyword present.
Adjusted default options for scipy_minimize to avoid repetitive warning messages.
Moved some functionality in init_dexp to separate _find_module function since it gets re-used,
simplified assignment of initial dexp phi.