### PR TITLE
Added support for per-module bounds defined in modelspecs.

### DIFF
--- a/nems/analysis/fit_basic.py
+++ b/nems/analysis/fit_basic.py
@@ -46,10 +46,12 @@ def fit_basic(data, modelspec,
         cost_function = basic_cost
 
     if require_phi:
-        # Ensure that phi exists for all modules; choose prior mean if not found
+        # Ensure that phi exists for all modules;
+        # choose prior mean if not found
         for i, m in enumerate(modelspec):
             if ('phi' not in m.keys()) and ('prior' in m.keys()):
-                log.debug('Phi not found for module, using mean of prior: %s', m)
+                log.debug('Phi not found for module, using mean of prior: %s',
+                          m)
                 m = nems.priors.set_mean_phi([m])[0]  # Inits phi for 1 module
                 modelspec[i] = m
 
@@ -74,12 +76,15 @@ def fit_basic(data, modelspec,
                       data=data, segmentor=segmentor, evaluator=evaluator,
                       metric=metric)
 
-    # get initial sigma value representing some point in the fit space
+    # get initial sigma value representing some point in the fit space,
+    # and corresponding bounds for each value
     sigma = packer(modelspec)
+    bounds_to_vec, _ = nems.fitters.mappers.bounds_vector(modelspec)
+    bounds = bounds_to_vec(modelspec)
 
     # Results should be a list of modelspecs
     # (might only be one in list, but still should be packaged as a list)
-    improved_sigma = fitter(sigma, cost_fn, **fit_kwargs)
+    improved_sigma = fitter(sigma, cost_fn, bounds=bounds, **fit_kwargs)
     improved_modelspec = unpacker(improved_sigma)
 
     elapsed_time = (time.time() - start_time)

--- a/nems/analysis/fit_iteratively.py
+++ b/nems/analysis/fit_iteratively.py
@@ -114,6 +114,9 @@ def _module_set_loop(subset, data, modelspec, cost_function, fitter,
         log.debug("Modelspec after freeze: %s", modelspec)
 
         packer, unpacker = mapper(modelspec)
+        bounds_to_vec, _ = nems.fitters.mappers.bounds_vector(modelspec)
+        bounds = bounds_to_vec(modelspec)
+
         # cost_function.counter = 0
         cost_function.error = None
         cost_fn = partial(cost_function,
@@ -122,7 +125,7 @@ def _module_set_loop(subset, data, modelspec, cost_function, fitter,
                           metric=metric)
         sigma = packer(modelspec)
 
-        improved_sigma = fitter(sigma, cost_fn, **fit_kwargs)
+        improved_sigma = fitter(sigma, cost_fn, bounds=bounds, **fit_kwargs)
         improved_modelspec = unpacker(improved_sigma)
 
         for i, m in enumerate(improved_modelspec):
@@ -229,4 +232,3 @@ def fit_iteratively(
     results = [copy.deepcopy(improved_modelspec)]
 
     return results
-

--- a/nems/distributions/exponential.py
+++ b/nems/distributions/exponential.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from .distribution import Distribution
 
+
 class Exponential(Distribution):
     '''
     Exponential Prior
@@ -19,4 +20,4 @@ class Exponential(Distribution):
         self.distribution = stats.expon(scale=beta)
 
     def __repr__(self):
-        return 'Exponential(β={})'.format(beta)
+        return 'Exponential(β={})'.format(self._beta)

--- a/nems/fitters/mappers.py
+++ b/nems/fitters/mappers.py
@@ -5,8 +5,9 @@ corresponding to the type of sigma expected by a fitter.
 Our proposed naming convention is to use whatever the modelspec is being
 turned into as the name for the mapper function.
 """
+import numpy as np
 
-from .util import phi_to_vector, vector_to_phi
+from nems.fitters.util import phi_to_vector, vector_to_phi
 
 
 def simple_vector(initial_modelspec):
@@ -33,5 +34,50 @@ def simple_vector(initial_modelspec):
         for i, p in enumerate(phi):
             tmp_modelspec[i]['phi'] = p
         return tmp_modelspec
+
+    return packer, unpacker
+
+
+def bounds_vector(initial_modelspec):
+    '''
+    Converts module bounds from a list of dictionaries to a flattened
+    vector.
+
+    Bounds are expected to be defined in the modelspec along the lines of:
+        {'fn': '...',
+         'phi': {'one': 'value', 'two': 'some other value', 'three': 'test'},
+         'bounds': {'one': (-1.0, 1.0), 'two': (0.0, None),
+                    'three': (None, None)}}
+    Note that each bound is a tuple of the form (lower_bound, upper_bound),
+    and a value of None is equivalent to negative or positive infinity.
+    The key specifying each bound must also correspond to a key in that
+    module's phi dictionary, though there does not need to be a bound
+    specified for every entry in phi.
+    '''
+
+    def packer(modelspec):
+        phi = [m.get('phi') for m in modelspec]
+        bounds = []
+        for i, p in enumerate(phi):
+            b = modelspec[i].get('bounds', None)
+            for k, v in p.items():
+                if np.isscalar(v):
+                    if b is None:
+                        # (None, None) is interpreted as no bounds by fitters
+                        bounds.append((None, None))
+                    else:
+                        bounds.append(b.get(k, (None, None)))
+                else:
+                    flattened = np.asanyarray(v).ravel()
+                    if b is None:
+                        bounds.extend([(None, None)]*flattened.size)
+                    else:
+                        bounds.extend([b.get(k, (None, None))]*flattened.size)
+
+        return bounds
+
+    def unpacker(vec):
+        raise NotImplementedError("No reason to unpack bounds vector, "
+                                  "they don't change during fitting.")
 
     return packer, unpacker


### PR DESCRIPTION
Added bounds_vector function in nems/fitters/mappers, which
returns a function that maps bounds dictionaries (with a structure
similar to phi) to a flattened vector for use by coordinate
descent and scipy_minimize fitters.

Incorporated bounds function into fit_basic and fit_iteratively,
as well as coordinate_descent and scipy_minimize.

Fixed a minor bug in distributions/exponential.py

As an aside, the bounds are set up to be perfectly happy with entire modelspecs
or parts of modelspecs that don't define bounds, or even defining bounds for one
parameter but not others. So this shouldn't create a need to start adding blank
bounds into all of our keywords - only the ones that need them.

Per the example in the docstring for bounds_vector, bounds can be defined in
the modelspec in a manner similar to phi:
{'fn': 'some.module', 'phi': {'p1': 1.0, 'p2': 2.0}, 'bounds': {'p1': (-3.0, 3.0), 'p2': (0.0, None)}}