### PR TITLE
Fix bug in copy of recording

### DIFF
--- a/nems/recording.py
+++ b/nems/recording.py
@@ -41,7 +41,13 @@ class Recording:
         '''
         Returns a copy of this recording.
         '''
-        return copy.copy(self)
+        signals = self.signals.copy()
+        other = Recording(signals)
+        for k, v in vars(self).items():
+            if k == 'signals':
+                continue
+            setattr(other, k, copy.copy(v))
+        return other
 
     @property
     def epochs(self):
@@ -57,6 +63,7 @@ class Recording:
         df = pd.concat(epoch_set, ignore_index=True)
         df.drop_duplicates(inplace=True)
         df.sort_values('start', inplace=True)
+        df.index = np.arange(len(df))
         return df
 
     # Defining __getitem__ and __setitem__ make recording objects behave

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -92,15 +92,15 @@ def test_select_times(recording):
     '''
     bounds = recording['dummy_signal_1'].get_epoch_bounds('trial2')
     newrec = recording.select_times(bounds)
-    
+
     # assert that pulls the correct length of data
-    assert newrec['dummy_signal_1'].as_continuous().shape == (3, 50) 
-    
+    assert newrec['dummy_signal_1'].as_continuous().shape == (3, 50)
+
     # assert that epochs outside of this time window no longer exist
     with pytest.raises(IndexError):
         newrec['dummy_signal_1'].extract_epoch('pupil_closed')
 
-    
+
 def test_recording_loading():
     '''
     Test the loading and saving of files to various HTTP/S3/File routes.
@@ -145,6 +145,7 @@ def test_recording_loading():
     #    print('Error saving to a directory URI')
     #    assert 0
 
+
 def test_recording_from_arrays():
     # need a list of array-like data structures
     x = np.random.rand(3, 200)
@@ -181,3 +182,9 @@ def test_recording_from_arrays():
         rec = Recording.load_from_arrays(arrays, rec_name, fs,
                                          sig_names=bad_names,
                                          signal_kwargs=kwargs)
+
+
+def test_recording_copy(recording):
+    # Ensure we get a true copy of recording
+    recording_copy = recording.copy()
+    assert id(recording.signals) != id(recording_copy.signals)


### PR DESCRIPTION
Copying the recording was not properly generating a copy of the signals
dictionary. Therefore, mutations to the signal dictionary were affecting
the original recording as well.