### PR TITLE
Better version of epoch averaging

### DIFF
--- a/nems/epoch.py
+++ b/nems/epoch.py
@@ -505,7 +505,7 @@ def find_common_epochs(epochs, epoch_name, d=12):
     # time so that they are relative to the beginning of the occurance of that
     # epoch.
     epoch_subsets = []
-    matches =  epochs.query(f'name == "{epoch_name}"')
+    matches =  epochs.query('name == "{}"'.format(epoch_name))
     for lb, ub in matches[['start', 'end']].values:
         m = (epochs['start'] >= lb) & (epochs['end'] <= ub)
         epoch_subset = epochs.loc[m].copy()

--- a/nems/epoch.py
+++ b/nems/epoch.py
@@ -1,5 +1,6 @@
 import re
 import numpy as np
+import pandas as pd
 
 import logging
 log = logging.getLogger(__name__)
@@ -473,3 +474,53 @@ def group_epochs_by_occurrence_counts(epochs, regex=None):
         else:
             d[count] = [name]
     return d
+
+
+def find_common_epochs(epochs, epoch_name, d=12):
+    '''
+    Finds all epochs contained by `epoch_name` that are common to all
+    occurances of `epoch_name`. An epoch is considered "common" to all
+    occurances if the name matches and the start and end times, relative to the
+    start `epoch_name`, are the same to the number of decimal places indicated.
+
+    Parameters
+    ----------
+    epochs : dataframe with 'name', 'start', 'end'
+        Epochs to filter through
+    epoch_name : str
+        Name of epoch to use
+    d : int
+        Number of decimal places to round start and end to. This is im portant
+        when comparing start and end times of different epochs due to
+        floating-point errors.
+
+    Result
+    ------
+    common_epochs : dataframe with 'name', 'start', 'end'
+        Epochs common to all occurances of `epoch_name`. The start and end
+        times will reflect the time relative to the onset of the epoch.
+    '''
+    # First, loop through all occurances of `epoch_name` and find all the
+    # epochs contained within that occurance. Be sure to adjust the start/end
+    # time so that they are relative to the beginning of the occurance of that
+    # epoch.
+    epoch_subsets = []
+    matches =  epochs.query(f'name == "{epoch_name}"')
+    for lb, ub in matches[['start', 'end']].values:
+        m = (epochs['start'] >= lb) & (epochs['end'] <= ub)
+        epoch_subset = epochs.loc[m].copy()
+        epoch_subset['start'] -= lb
+        epoch_subset['end'] -= lb
+        epoch_subset = set((n, round(s, d), round(e, d)) for (n, s, e) \
+                           in epoch_subset[['name', 'start', 'end']].values)
+        epoch_subsets.append(epoch_subset)
+
+    # Now, determine which epochs are common to all occurances.
+    common_epochs = epoch_subsets[0].copy()
+    for other_epoch in epoch_subsets[1:]:
+        common_epochs.intersection_update(other_epoch)
+
+    new_epochs = pd.DataFrame(list(common_epochs),
+                              columns=['name', 'start', 'end'])
+    new_epochs.sort_values(['start', 'end'], inplace=True)
+    return new_epochs

--- a/nems/preprocessing.py
+++ b/nems/preprocessing.py
@@ -2,7 +2,7 @@ import warnings
 import numpy as np
 import nems.epoch as ep
 import pandas as pd
-import nems.signal as signal
+from nems.signal import RasterizedSignal
 import copy
 
 import logging
@@ -69,7 +69,7 @@ def add_average_sig(rec, signal_to_average='resp',
     return newrec
 
 
-def average_away_epoch_occurrences(rec, epoch_regex='^STIM_'):
+def average_away_epoch_occurrences(recording, epoch_regex='^STIM_'):
     '''
     Returns a recording with _all_ signals averaged across epochs that
     match epoch_regex, shortening them so that each epoch occurs only
@@ -93,64 +93,42 @@ def average_away_epoch_occurrences(rec, epoch_regex='^STIM_'):
     (based on stimulus and behaviorial state, for example) and then match
     the epoch_regex to those.
     '''
+    epochs = recording.epochs
+    epoch_names = sorted(set(ep.epoch_names_matching(epochs, epoch_regex)))
 
-    # Create new recording
-    newrec = rec.copy()
+    offset = 0
+    new_epochs = []
+    for epoch_name in epoch_names:
+        common_epochs = ep.find_common_epochs(epochs, epoch_name)
+        end = common_epochs.query(f'name == "{epoch_name}"').iloc[0]['end']
+        common_epochs[['start', 'end']] += offset
+        offset += end
+        new_epochs.append(common_epochs)
+    new_epochs = pd.concat(new_epochs, ignore_index=True)
 
-    counter = 0
+    averaged_recording = recording.copy()
 
-    # iterate through each signal
-    for signal_name, signal_to_average in rec.signals.items():
-        # TODO: for TiledSignals, there is a much simpler way to do this!
+    for signal_name, signal in recording.signals.items():
+        # TODO: this may be better done as a method in signal subclasses since
+        # some subclasses may have more efficient approaches (e.g.,
+        # TiledSignal)
 
-        # 0. rasterize
-        signal_to_average = signal_to_average.rasterize()
+        # Extract all occurances of each epoch, returning a dict where keys are
+        # stimuli and each value in the dictionary is (reps X cell X bins)
+        epoch_data = signal.rasterize().extract_epochs(epoch_names)
 
-        # 1. Find matching epochs
-        epochs_to_extract = ep.epoch_names_matching(rec.epochs, epoch_regex)
+        # Average over all occurrences of each epoch
+        for epoch_name, epoch in epoch_data.items():
+            epoch_data[epoch_name] = np.nanmean(epoch, axis=0)
+        data = [epoch_data[epoch_name] for epoch_name in epoch_names]
+        data = np.concatenate(data, axis=-1)
+        if data.shape[-1] != round(signal.fs * offset):
+            raise ValueError('Misalignment issue in averaging signal')
 
-        # 2. Fold over all stimuli, returning a dict where keys are stimuli
-        #    and each value in the dictionary is (reps X cell X bins)
-        folded_matrices = signal_to_average.extract_epochs(epochs_to_extract)
+        averaged_signal = signal._modified_copy(data, epochs=new_epochs)
+        averaged_recording.add_signal(averaged_signal)
 
-        # force a standard list of sorted keys for all signals
-        if counter == 0:
-            sorted_keys = list(folded_matrices.keys())
-            sorted_keys.sort()
-        counter += 1
-
-        # 3. Average over all occurrences of each epoch, and append to data
-        fs = signal_to_average.fs
-        data = np.zeros([signal_to_average.nchans, 0])
-        current_time = 0
-        epochs = None
-        for k in sorted_keys:
-            # Supress warnings about all-nan matrices
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                per_stim_psth = np.nanmean(folded_matrices[k], axis=0)
-            data = np.concatenate((data, per_stim_psth), axis=1)
-            epoch = current_time+np.array([[0, per_stim_psth.shape[1]/fs]])
-            df = pd.DataFrame(np.tile(epoch, [2, 1]), columns=['start', 'end'])
-            df['name'] = k
-            df.at[1, 'name'] = 'TRIAL'
-            if epochs is not None:
-                epochs = epochs.append(df, ignore_index=True)
-            else:
-                epochs = df
-            current_time = epoch[0, 1]
-            # print("{0} epoch: {1}-{2}".format(k,epoch[0,0],epoch[0,1]))
-
-        avg_signal = signal.RasterizedSignal(
-                fs=fs, data=data,
-                name=signal_to_average.name,
-                recording=signal_to_average.recording,
-                chans=signal_to_average.chans,
-                epochs=epochs,
-                meta=signal_to_average.meta)
-        newrec.add_signal(avg_signal)
-
-    return newrec
+    return averaged_recording
 
 
 def remove_invalid_segments(rec):
@@ -473,7 +451,7 @@ def make_state_signal(rec, state_signals=['pupil'], permute_signals=[],
         # print(state_sig_list[-1])
         # print(state_sig_list[-1].shape)
 
-    state = signal.RasterizedSignal.concatenate_channels(state_sig_list)
+    state = RasterizedSignal.concatenate_channels(state_sig_list)
     state.name = new_signalname
 
     # scale all signals to range from 0 - 1
@@ -559,7 +537,7 @@ def make_contrast_signal(rec, name='contrast', source_name='stim', ms=500,
     Only supports RasterizedSignal.
     '''
     source_signal = rec[source_name]
-    if not isinstance(source_signal, signal.RasterizedSignal):
+    if not isinstance(source_signal, RasterizedSignal):
         raise TypeError("signal with key {} was not a RasterizedSignal"
                         .format(source_name))
     array = source_signal.as_continuous()

--- a/nems/preprocessing.py
+++ b/nems/preprocessing.py
@@ -100,7 +100,8 @@ def average_away_epoch_occurrences(recording, epoch_regex='^STIM_'):
     new_epochs = []
     for epoch_name in epoch_names:
         common_epochs = ep.find_common_epochs(epochs, epoch_name)
-        end = common_epochs.query(f'name == "{epoch_name}"').iloc[0]['end']
+        query = 'name == "{}"'.format(epoch_name)
+        end = common_epochs.query(query).iloc[0]['end']
         common_epochs[['start', 'end']] += offset
         offset += end
         new_epochs.append(common_epochs)

--- a/nems/signal.py
+++ b/nems/signal.py
@@ -275,7 +275,6 @@ class SignalBase:
         basepath = os.path.join(dirpath, filebase)
         jsonfilepath = basepath + '.json'
         epochfilepath = basepath + '.epoch.csv'
-        print(jsonfilepath)
         with open(jsonfilepath, 'w') as md_fh, open(epochfilepath, 'w') as epoch_fh:
             self._save_metadata(epoch_fh, md_fh, fmt)
         return (jsonfilepath, epochfilepath)
@@ -1135,12 +1134,6 @@ class RasterizedSignal(SignalBase):
 
         data[mask] = np.nan
         data[~mask2] = np.nan
-
-#        if self.name == 'resp':
-#            sig_len = data.shape[1]
-#            sig_valid = np.sum(np.isfinite(data[0,:]))
-#            log.info("%s valid samples: %d/%d (%d)", self.name, sig_valid,
-#                     sig_valid_start, sig_len)
 
         return self._modified_copy(data)
 

--- a/tests/test_epoch.py
+++ b/tests/test_epoch.py
@@ -1,10 +1,11 @@
 import pytest
 
 import numpy as np
+import pandas as pd
 
 from nems.epoch import (epoch_union, epoch_difference, epoch_intersection,
                         epoch_contains, epoch_contained, adjust_epoch_bounds,
-                        remove_overlap)
+                        remove_overlap, find_common_epochs)
 
 @pytest.fixture()
 def epoch_a():
@@ -200,3 +201,32 @@ def test_remove_overlap():
     actual = remove_overlap(epochs)
     assert np.all(actual == expected)
 
+
+def test_find_common_epochs():
+    epochs = [
+        ['parent', 1, 11],
+        ['child_a', 1, 2],
+        ['child_b', 1, 6],
+        ['child_c', 6, 7],
+        ['child_d', 7, 11],
+        ['child_e', 9, 11],
+        ['parent', 30, 40],
+        ['child_a', 30, 31],
+        ['child_b', 30, 35],
+        ['child_c', 35, 36],
+        ['child_d', 36, 40],
+    ]
+    epochs = pd.DataFrame(epochs, columns=['name', 'start', 'end'])
+
+    expected = {
+        ('parent', 0, 10),
+        ('child_a', 0, 1),
+        ('child_b', 0, 5),
+        ('child_c', 5, 6),
+        ('child_d', 6, 10),
+    }
+    expected = set(expected)
+
+    result = find_common_epochs(epochs, 'parent')
+    result = set((n, s, e) for n, s, e in result.values)
+    assert result == expected

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,84 @@
+import pytest
+
+import numpy as np
+import pandas as pd
+
+from nems.signal import RasterizedSignal
+from nems.recording import Recording
+from nems.preprocessing import average_away_epoch_occurrences
+
+
+def make_signal(signal_name='dummy_signal_1', recording_name='dummy_recording',
+            fs=50, nchans=3, ntimes=300):
+    '''
+    Generates a dummy signal with a predictable structure (every element
+    increases by 1) that is useful for testing.
+    '''
+    # Generate a numpy array that's incrementially increasing across channels,
+    # then across timepoints, by 1.
+    c = np.arange(nchans, dtype=np.float)
+    t = np.arange(ntimes, dtype=np.float)
+    data = c[..., np.newaxis] + t*nchans
+
+    epochs = pd.DataFrame({
+        'start': [0,  50, 100, 250],
+        'end':   [49, 99, 149, 299],
+        'name': ['stim1', 'stim2', 'stim1', 'stim2']
+        })
+    epochs['start'] /= fs
+    epochs['end'] /= fs
+    kwargs = {
+        'data': data,
+        'name': signal_name,
+        'recording': recording_name,
+        'chans': ['chan' + str(n) for n in range(nchans)],
+        'epochs': epochs,
+        'fs': fs,
+        'meta': {
+            'for_testing': True,
+            'date': "2018-01-10",
+            'animal': "Donkey Hotey",
+            'windmills': 'tilting'
+        },
+    }
+    return RasterizedSignal(**kwargs)
+
+
+@pytest.fixture()
+def signal1():
+    return make_signal(signal_name='resp',
+                       recording_name='dummy_recording', fs=50, nchans=3,
+                       ntimes=300)
+
+
+@pytest.fixture()
+def signal2():
+    return make_signal(signal_name='stim',
+                       recording_name='dummy_recording', fs=50, nchans=3,
+                       ntimes=300)
+
+
+@pytest.fixture()
+def recording(signal1, signal2):
+    signals = {signal1.name: signal1,
+               signal2.name: signal2}
+    return Recording(signals)
+
+
+def test_average_away_epoch_occurrences(recording):
+    averaged_recording = average_away_epoch_occurrences(recording, '^stim')
+    as1 = averaged_recording['stim'].extract_epoch('stim1')
+    as2 = averaged_recording['stim'].extract_epoch('stim2')
+    s1 = recording['stim'].extract_epoch('stim1')
+    s2 = recording['stim'].extract_epoch('stim2')
+
+    assert as1.shape == (1, 3, 49)
+    assert s1.shape == (2, 3, 49)
+    assert np.all(as1[0] == np.mean(s1, axis=0))
+    assert np.all(as2[0] == np.mean(s2, axis=0))
+
+    epochs = averaged_recording['stim'].epochs[['name', 'start', 'end']]
+    assert epochs.iat[0, 0] == 'stim1'
+    assert epochs.iat[1, 0] == 'stim2'
+    assert epochs.iat[0, 2] == 0.98
+    assert epochs.iat[1, 2] == 1.96


### PR DESCRIPTION
This uses a simpler, more Pythonic algorithm for creating the averaged
recording, fixes a few bugs (mainly with mutability of objects) and
preserves any "sub-epochs" (i.e., epochs contained within the epochs
being averaged) that are common to all the epochs.

As a bonus, includes new unit tests (we need more of these).