### PR TITLE
simplify FIR

### DIFF
--- a/nems/modules/fir.py
+++ b/nems/modules/fir.py
@@ -54,7 +54,7 @@ def per_channel(x, coefficients, bank_count=1):
         all_x = chain.from_iterable(repeat(x_i, bank_count) for x_i in x)
     else:
         if bank_count == 1:
-            desc = '%i FIR filters' % len(coefficients)
+            desc = '%i FIR filters' % n_filters
         else:
             desc = '%i FIR filter banks' % n_banks
         raise ValueError(

--- a/nems/modules/fir.py
+++ b/nems/modules/fir.py
@@ -1,3 +1,5 @@
+from itertools import chain, repeat
+
 import numpy as np
 import scipy.signal
 
@@ -39,54 +41,37 @@ def per_channel(x, coefficients, bank_count=1):
     # provided (we have a separate filter for each channel). The `zip` function
     # doesn't require the iterables to be the same length.
     n_in = len(x)
-    if len(coefficients) == n_in:
+    n_filters = len(coefficients)
+    n_banks = int(n_filters / bank_count)
+    if n_filters == n_in:
         # option 1: number of input channels is same as total channels in the
         # filterbank, allowing a different stimulus into each filter
-        input_channels_already_repeating = True
-        i_bank = -1
-        channels_per_bank = n_in / bank_count
-
-    elif len(coefficients) == n_in * bank_count:
+        all_x = x
+    elif n_filters == n_in * bank_count:
         # option 2: number of input channels is same as number of coefficients
         # in each fir filter, so that the same stimulus goes into each
         # filter
-        input_channels_already_repeating = False
-
+        all_x = chain.from_iterable(repeat(x_i, bank_count) for x_i in x)
     else:
         if bank_count == 1:
             desc = '%i FIR filters' % len(coefficients)
         else:
-            n_banks = len(coefficients) / bank_count
             desc = '%i FIR filter banks' % n_banks
         raise ValueError(
             'Dimension mismatch. %s channels provided for %s.' % (n_in, desc))
 
+    c_iter = iter(coefficients)
     out = np.zeros((bank_count, x.shape[1]))
     for i_in in range(n_in):
-        x_ = x[i_in]
-
-        # It is slightly more "correct" to use lfilter than convolve at
-        # edges, but but also about 25% slower (Measured on Intel Python
-        # Dist, using i5-4300M)
-
-        # TODO: Can probably simplify so there is not redundancy in these two
-        # conditions.
-        if input_channels_already_repeating:
-            if i_in % channels_per_bank == 0:
-                i_bank += 1
-            c = coefficients[i_in]
+        for i_out in range(bank_count):
+            x_ = next(all_x)
+            c = next(c_iter)
+            # It is slightly more "correct" to use lfilter than convolve at
+            # edges, but but also about 25% slower (Measured on Intel Python
+            # Dist, using i5-4300M)
             zi = get_zi(c, x_)
             r, zf = scipy.signal.lfilter(c, [1], x_, zi=zi)
-            out[i_bank] += r
-
-        else:
-            for i_bank in range(bank_count):
-                c = coefficients[i_in * bank_count + i_bank]
-                zi = get_zi(c, x_)
-                r, zf = scipy.signal.lfilter(c, [1], x_, zi=zi)
-                # TODO: Use convolve. Why is this giving the wrong answer?
-                # r = np.convolve(c, x, mode='same')
-                out[i_bank] += r
+            out[i_out] += r
     return out
 
 

--- a/nems/modules/fir.py
+++ b/nems/modules/fir.py
@@ -46,7 +46,7 @@ def per_channel(x, coefficients, bank_count=1):
     if n_filters == n_in:
         # option 1: number of input channels is same as total channels in the
         # filterbank, allowing a different stimulus into each filter
-        all_x = x
+        all_x = iter(x)
     elif n_filters == n_in * bank_count:
         # option 2: number of input channels is same as number of coefficients
         # in each fir filter, so that the same stimulus goes into each


### PR DESCRIPTION
I think this would remove the redundancy, but haven't tested it! Is there a function to retrieve a small standard `Recording` dataset to use for testing? Or if not, what about adding a function that generates some random data?