### PR TITLE
Fix bug in epoch_intersection

### DIFF
--- a/nems/epoch.py
+++ b/nems/epoch.py
@@ -216,7 +216,7 @@ def epoch_intersection_full(a, b):
 
 
 @check_result
-def epoch_intersection(a, b):
+def epoch_intersection(a, b, precision=6):
     '''
     Compute the intersection of the epochs. Only regions in a which overlap with
     b will be kept.
@@ -229,6 +229,8 @@ def epoch_intersection(a, b):
     b : 2D array of (N x 2)
         The first column is the start time and second column is the end time. N
         is the number of occurances of b.
+    precision : int
+        Number of decimal places to use for equality test.
 
     Returns
     -------
@@ -244,6 +246,8 @@ def epoch_intersection(a, b):
     '''
     # Convert to a list and then sort in reversed order such that pop() walks
     # through the occurences from earliest in time to latest in time.
+    a = np.around(a, precision)
+    b = np.around(b, precision)
     a = a.tolist()
     a.sort(reverse=True)
     b = b.tolist()

--- a/tests/test_epoch.py
+++ b/tests/test_epoch.py
@@ -69,6 +69,36 @@ def test_intersection(epoch_a, epoch_b):
     assert np.all(result == expected)
 
 
+def test_intersection_bug():
+    # Copied from real data
+    a = np.array([
+        [57.7, 61.4],
+        [61.4, 66.6],
+        [66.6, 70.9],
+        [70.9, 75.80000000000001],
+        [75.8, 81.0],
+    ])
+
+    b = np.array([
+        [57.7000000000001, 61.4000000000001],
+        [61.4000000000001, 66.6000000000001],
+        [66.6000000000001, 70.9],
+        [75.8000000000001, 81.0000000000001],
+        [81.0000000000001, 85.6000000000001],
+    ])
+
+    expected = np.array([
+        [57.7, 61.4],
+        [61.4, 66.6],
+        [66.6, 70.9],
+        [75.8, 81.0],
+    ])
+
+    result = epoch_intersection(a, b)
+    print(result)
+    assert np.all(result == expected)
+
+
 def test_intersection_float(epoch_a, epoch_b):
     expected = np.array([
         [ 60,  70],


### PR DESCRIPTION
Floating-point imprecision can lead to nasty bugs when attempting to
compare epoch boundaries. This allows us to specify a precision when
performing an epoch_intersection operation.

Also fixes a subtle bug when end of an epoch in b matches start of an
epoch in a.