### PR TITLE
Added utilities for escaping characters in keywords

### DIFF
--- a/nems/plugins/default_initializers.py
+++ b/nems/plugins/default_initializers.py
@@ -1,11 +1,13 @@
 import logging
 import re
 
+from nems.utils import escaped_split
+
 log = logging.getLogger(__name__)
 
 
 def init(kw):
-    ops = kw.split('.')[1:]
+    ops = escaped_split(kw, '.')[1:]
     st = False
     tolerance = 10**-5.5
 
@@ -13,8 +15,9 @@ def init(kw):
         if op == 'st':
             st = True
         elif op.startswith('t'):
-            # 'd' stands in for '.' in floating points
-            num = op.replace('d', '.')
+            # Should use \ to escape going forward, but keep d-sub in
+            # for backwards compatibility.
+            num = op.replace('d', '.').replace('\\', '')
             tolpower = float(num[1:])*(-1)
             tolerance = 10**tolpower
 

--- a/nems/utils.py
+++ b/nems/utils.py
@@ -87,3 +87,36 @@ def find_module(query, modelspec, find_all_matches=False, key='fn'):
                   query, target_i)
 
     return target_i
+
+
+def escaped_split(string, delimiter):
+    '''
+    Allows escaping of characters when splitting a string to a list,
+    useful for some arguments in keyword strings that need to use
+    underscores, decimals, hyphens, or other characters parsed by
+    the keyword system.
+    '''
+    x = 'EXTREMELYUNLIKELYTOEVERENCOUNTERTHISEXACTSTRINGANYWHEREELSE'
+    match = "\%s" % delimiter
+    temp = string.replace(match, x)
+    temp_split = temp.split(delimiter)
+    final_split = [s.replace(x, match) for s in temp_split]
+
+    return final_split
+
+
+def escaped_join(list, delimiter):
+    '''
+    Allows escaping of characters when joining a list of strings,
+    useful for some arguments in keyword strings that need to use
+    underscores, decimals, hyphens, or other characters parsed by
+    the keyword system.
+    '''
+    x = 'EXTREMELYUNLIKELYTOEVERENCOUNTERTHISEXACTSTRINGANYWHEREELSE'
+    match = "\%s" % delimiter
+    temp = [s.replace(match, x) for s in list]
+    temp_join = delimiter.join(temp)
+    final_join = temp_join.replace(x, match)
+
+    return final_join
+

--- a/nems/xform_helper.py
+++ b/nems/xform_helper.py
@@ -49,7 +49,7 @@ def generate_xforms_spec(recording_uri, modelname, meta={}, xforms_kwargs={},
     # TODO: naming scheme change: pre_modules, modules, post_modules?
     #       or something along those lines... since they aren't really
     #       just loaders and fitters
-    load_keywords, model_keywords, fit_keywords = modelname.split("_")
+    load_keywords, model_keywords, fit_keywords = escaped_split(modelname, '_')
 
     xforms_lib = KeywordRegistry(recording_uri=recording_uri, **xforms_kwargs)
     xforms_lib.register_modules([default_loaders, default_fitters,

--- a/nems/xforms.py
+++ b/nems/xforms.py
@@ -222,8 +222,8 @@ def fill_in_default_metadata(rec, modelspecs, IsReload=False, **context):
     return {'modelspecs': modelspecs}
 
 
-def only_best_modelspec(modelspecs, metakey='r_test', IsReload=False,
-                        **context):
+def only_best_modelspec(modelspecs, metakey='r_test', comparison='greatest',
+                        IsReload=False, **context):
     '''
     Collapses a list of modelspecs so that it only contains the modelspec
     with the highest given meta metric.
@@ -234,7 +234,8 @@ def only_best_modelspec(modelspecs, metakey='r_test', IsReload=False,
 
         # TODO: Make this allow for variable number of top specs by
         #       updating ms function to sort then pick top n
-        return {'modelspecs': ms.get_best_modelspec(modelspecs, metakey)}
+        return {'modelspecs': ms.get_best_modelspec(modelspecs, metakey,
+                                                    comparison)}
     else:
         return {}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+from nems.utils import escaped_split, escaped_join
+
+def test_split_and_join():
+    s = 'my-escaped_modelspec-name_blah.t5\.5'
+    x = escaped_split(s, '_')
+    # escaping the . shouldn't matter here, should only escape
+    # the active delimiter
+    assert len(x) == 3
+    blah = x[2]
+
+    # now the . should be ignored during the split, for a length
+    # of 2 instead of 3
+    assert len(escaped_split(blah, '.')) == 2
+
+    # after the reverse operation, original string shouldl be preserved
+    y = escaped_join(x, '_')
+    assert y == s


### PR DESCRIPTION
Added functions escaped_split and escaped_join to
nems.utils and incorporated them into the keyword parsing
system used by xforms, as well as some default keywords.

For example, when specifying tolerance levels that are
not whole number powers, the following will now work:
`basic.t5\.5`

The syntax of substituting a 'd' for the decimal is still
supported, but using a \ for escaping should be used
going forward since it allows for a generic syntax that
can be applied to all keyword arguments (like escaping
underscores)  and is already
a standard for string parsing in general.