### PR TITLE
Cleanup plugin loader to allow module names

### DIFF
--- a/tests/resources/plugin1.py
+++ b/tests/resources/plugin1.py
@@ -1,0 +1,2 @@
+def firstkw(kwstring):
+    return {}

--- a/tests/resources/plugin2.py
+++ b/tests/resources/plugin2.py
@@ -1,0 +1,2 @@
+def secondkw(kwstring):
+    return {}

--- a/tests/test_plugins_registry.py
+++ b/tests/test_plugins_registry.py
@@ -66,6 +66,30 @@ def test_fitter_registry(fitter_registry):
         x = fitter_registry[t]
 
 
+def test_register_plugins():
+    registry = KeywordRegistry()
+    registry.register_plugins(['resources/plugin1.py'])
+    registry['firstkw']
+    with pytest.raises(KeyError):
+        registry['secondkw']
+    registry.register_plugins(['resources/plugin2.py'])
+    registry['secondkw']
+
+    # Hack to test importable module names
+    import sys
+    import os
+    sys.path.append(os.path.dirname(__file__))
+    registry = KeywordRegistry()
+    registry.register_plugins(['resources.plugin1'])
+    registry['firstkw']
+    with pytest.raises(KeyError):
+        registry['secondkw']
+
+    registry.register_plugins(['resources'])
+    registry['firstkw']
+    registry['secondkw']
+
+
 def test_jsonify(model_registry):
     json = model_registry.to_json()
     unjson = KeywordRegistry.from_json(json)


### PR DESCRIPTION
Previous iteration only allowed for importing keywords from files and/or
directories. Cleaned up the file/directory import mechanism using
features specific to Python 3.6+ as it's best not to muck around with
sys.path too much.

Also, added support for specifying plugins as module names (e.g.,
`nems_db.nems_lbhb.plugin`) instead of a path to the file. This makes
the code much more portable.