### PR TITLE
Fix bug introduced by revamp of model registry

### DIFF
--- a/tests/test_plugins_registry.py
+++ b/tests/test_plugins_registry.py
@@ -17,6 +17,7 @@ def loader_registry():
 def model_registry():
     models = KeywordRegistry()
     models.register_module(default_keywords)
+    models.register_plugins(['resources/plugin1.py'])
     return models
 
 
@@ -94,4 +95,3 @@ def test_jsonify(model_registry):
     json = model_registry.to_json()
     unjson = KeywordRegistry.from_json(json)
     unjson.keywords == model_registry.keywords
-    return json, unjson


### PR DESCRIPTION
New import system for files broke the JSONification of the registry.
Fixed this by adding a source_string to the Keyword object that's used
to identify how to locate the keyword. This allows us to preserve the
original method of finding the keyword (e.g., via an import or by
specifying the file).