### PR TITLE
awctomlinson/nwb-neuropixel-file-support

### DIFF
--- a/nems/recording.py
+++ b/nems/recording.py
@@ -353,7 +353,7 @@ class Recording:
           - https://pynwb.readthedocs.io/en/latest/index.html
 
         :param nwb_file: path to the nwb file
-        :param nwb_format: specifier for how the data is saved container
+        :param nwb_format: specifier for how the data is saved in the container
 
         :return: a recording object
         """
@@ -368,9 +368,9 @@ class Recording:
 
         if nwb_format == 'neuropixel':
             """
-            In neuropixel nwb files, data is stored in several attributes of the container: 
-              - units: individual cell metadata, a pandas dataframe
-              - epochs: timing of the stimuli, series of xarrays
+            In neuropixel ecephys nwb files, data is stored in several attributes of the container: 
+              - units: individual cell metadata, a dataframe
+              - epochs: timing of the stimuli, series of arrays
               - lab_meta_data: metadata about the experiment, such as specimen details
               
             Spike times are saved as arrays in the 'spike_times' column of the units dataframe as xarrays. 
@@ -380,13 +380,12 @@ class Recording:
               - https://allensdk.readthedocs.io/en/latest/visual_coding_neuropixels.html
               - https://allensdk.readthedocs.io/en/latest/_static/examples/nb/ecephys_quickstart.html
               - https://allensdk.readthedocs.io/en/latest/_static/examples/nb/ecephys_data_access.html
-                         
             """
             try:
                 from pynwb import NWBHDF5IO
                 from allensdk.brain_observatory.ecephys import nwb  # needed for ecephys format compat
             except ImportError:
-                m = 'allensdk library is required to work with neuropixel nwb formats.'
+                m = 'The "allensdk" library is required to work with neuropixel nwb formats, available on PyPI.'
                 log.error(m)
                 raise ImportError(m)
 
@@ -407,9 +406,8 @@ class Recording:
                 # build the units metadata
                 units_data = {
                     col.name: col.data for col in units.columns
-                    if
-                    col.name not in ['spike_times', 'spike_times_index', 'spike_amplitudes', 'spike_amplitudes_index',
-                                     'waveform_mean', 'waveform_mean_index']
+                    if col.name not in ['spike_times', 'spike_times_index', 'spike_amplitudes',
+                                        'spike_amplitudes_index', 'waveform_mean', 'waveform_mean_index']
                 }
 
                 # needs to be a dict

--- a/nems/recording.py
+++ b/nems/recording.py
@@ -1,24 +1,25 @@
-import io
-import os
-import gzip
-import time
-import tarfile
-import logging
-import requests
-import pandas as pd
-import numpy as np
 import copy
-import tempfile
-import shutil
+import io
 import json
+import logging
+import os
+import shutil
+import tarfile
+import tempfile
+import time
 import warnings
+from pathlib import Path
 
-from nems.uri import local_uri, http_uri, targz_uri
+import numpy as np
+import pandas as pd
+import requests
+
 import nems.epoch as ep
-from nems.signal import SignalBase, RasterizedSignal, merge_selections, \
-                        list_signals, load_signal, load_signal_from_streams
-from nems.utils import recording_filename_hash
 from nems import get_setting
+from nems.signal import SignalBase, RasterizedSignal, PointProcess, merge_selections, \
+    list_signals, load_signal, load_signal_from_streams
+from nems.uri import local_uri, http_uri, targz_uri
+from nems.utils import recording_filename_hash
 
 log = logging.getLogger(__name__)
 
@@ -340,6 +341,98 @@ class Recording:
         signals = {s.name:s for s in signals}
         # Combine into recording and return
         return Recording(signals)
+
+    @classmethod
+    def from_nwb(cls, nwb_file, nwb_format):
+        """
+        The NWB (Neurodata Without Borders) format is a unified data format developed by the Allen Brain Institute.
+        Data is stored as an HDF5 file, with the format varying depending how the data was saved.
+        
+        References:
+          - https://nwb.org
+          - https://pynwb.readthedocs.io/en/latest/index.html
+
+        :param nwb_file: path to the nwb file
+        :param nwb_format: specifier for how the data is saved container
+
+        :return: a recording object
+        """
+        log.info(f'Loading NWB file with format "{nwb_format}" from "{nwb_file}".')
+
+        # add in supported nwb formats here
+        assert nwb_format in ['neuropixel'], f'"{nwb_format}" not a supported NWB file format.'
+
+        nwb_filepath = Path(nwb_file)
+        if not nwb_filepath.exists():
+            raise FileNotFoundError(f'"{nwb_file}" could not be found.')
+
+        if nwb_format == 'neuropixel':
+            """
+            In neuropixel nwb files, data is stored in several attributes of the container: 
+              - units: individual cell metadata, a pandas dataframe
+              - epochs: timing of the stimuli, series of xarrays
+              - lab_meta_data: metadata about the experiment, such as specimen details
+              
+            Spike times are saved as arrays in the 'spike_times' column of the units dataframe as xarrays. 
+            The frequency is 1250.
+              
+            Refs:
+              - https://allensdk.readthedocs.io/en/latest/visual_coding_neuropixels.html
+              - https://allensdk.readthedocs.io/en/latest/_static/examples/nb/ecephys_quickstart.html
+              - https://allensdk.readthedocs.io/en/latest/_static/examples/nb/ecephys_data_access.html
+                         
+            """
+            try:
+                from pynwb import NWBHDF5IO
+                from allensdk.brain_observatory.ecephys import nwb  # needed for ecephys format compat
+            except ImportError:
+                m = 'allensdk library is required to work with neuropixel nwb formats.'
+                log.error(m)
+                raise ImportError(m)
+
+            session_name = nwb_filepath.stem
+
+            with NWBHDF5IO(str(nwb_filepath), 'r') as nwb_io:
+                nwbfile = nwb_io.read()
+
+                units = nwbfile.units
+                epochs = nwbfile.epochs
+
+                spike_times = dict(zip(units.id[:], units['spike_times'][:]))
+
+                # extract the metadata and convert to dict
+                metadata = nwbfile.lab_meta_data['metadata'].to_dict()
+                metadata['uri'] = str(nwb_filepath)  # add in uri
+
+                # build the units metadata
+                units_data = {
+                    col.name: col.data for col in units.columns
+                    if
+                    col.name not in ['spike_times', 'spike_times_index', 'spike_amplitudes', 'spike_amplitudes_index',
+                                     'waveform_mean', 'waveform_mean_index']
+                }
+
+                # needs to be a dict
+                units_meta = pd.DataFrame(units_data, index=units.id[:]).to_dict('index')
+
+                # build the epoch dataframe
+                epoch_data = {
+                    col.name: col.data for col in epochs.columns
+                    if col.name not in ['tags', 'timeseries', 'tags_index', 'timeseries_index']
+                }
+
+                epoch_df = pd.DataFrame(epoch_data, index=epochs.id[:]).rename({
+                    'start_time': 'start',
+                    'stop_time': 'end',
+                    'stimulus_name': 'name'
+                }, axis='columns')
+
+                # save the spike times as a point process signal
+                pp = PointProcess(1250, spike_times, name='spike_times', recording=session_name, epochs=epoch_df,
+                                  meta=units_meta)
+
+                log.info('Successfully loaded nwb file.')
+                return cls({pp.recording: pp}, meta=metadata)
 
     def save(self, uri='', uncompressed=False):
         '''

--- a/notebooks/demo_working_with_nwb_files.ipynb
+++ b/notebooks/demo_working_with_nwb_files.ipynb
@@ -1,0 +1,1401 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nems.configs.defaults INFO] Saving log messages to /tmp/nems/NEMS 2019-12-10 155251.log\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "import json\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from allensdk.brain_observatory.ecephys.ecephys_project_cache import EcephysProjectCache\n",
+    "from allensdk.brain_observatory.ecephys.ecephys_session import EcephysSession\n",
+    "\n",
+    "from allensdk.brain_observatory.ecephys import nwb  # for compat\n",
+    "import pynwb\n",
+    "from pynwb import NWBHDF5IO\n",
+    "\n",
+    "import nems\n",
+    "from nems.recording import Recording\n",
+    "from nems.signal import PointProcess\n",
+    "\n",
+    "import h5py\n",
+    "\n",
+    "from matplotlib import pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate session and get metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = Path(r'data')\n",
+    "manifest_path = data_dir / 'manifest.json'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`manifest.json` is where the library keeps a record of previously downloaded files. If it doesn't exists in location you specify, it will be created\n",
+    "the first time you create the cache object. Otherwise, when you request data, the library will check the manifest to see if it's been downloaded."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assert manifest_path.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[numexpr.utils INFO] NumExpr defaulting to 8 threads.\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n"
+     ]
+    }
+   ],
+   "source": [
+    "cache = EcephysProjectCache.from_warehouse(manifest=manifest_path)\n",
+    "sessions = cache.get_session_table()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Download data from session"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can edit the download criteria to filter out the data. Downloading the data can take several minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 21 is just a random number, for this example notebook\n",
+    "session = cache.get_session_data(sessions.iloc[21].name,\n",
+    "                                 isi_violations_maximum=np.inf,\n",
+    "                                 amplitude_cutoff_maximum=np.inf,\n",
+    "                                 presence_ratio_minimum=-np.inf\n",
+    "                                )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the epochs table. It applies to all the units."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>color</th>\n",
+       "      <th>contrast</th>\n",
+       "      <th>frame</th>\n",
+       "      <th>orientation</th>\n",
+       "      <th>phase</th>\n",
+       "      <th>pos</th>\n",
+       "      <th>size</th>\n",
+       "      <th>spatial_frequency</th>\n",
+       "      <th>start_time</th>\n",
+       "      <th>stimulus_block</th>\n",
+       "      <th>stimulus_name</th>\n",
+       "      <th>stop_time</th>\n",
+       "      <th>temporal_frequency</th>\n",
+       "      <th>x_position</th>\n",
+       "      <th>y_position</th>\n",
+       "      <th>duration</th>\n",
+       "      <th>stimulus_condition_id</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>stimulus_presentation_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>null</td>\n",
+       "      <td>null</td>\n",
+       "      <td>null</td>\n",
+       "      <td>null</td>\n",
+       "      <td>null</td>\n",
+       "      <td>null</td>\n",
+       "      <td>null</td>\n",
+       "      <td>null</td>\n",
+       "      <td>24.752216</td>\n",
+       "      <td>null</td>\n",
+       "      <td>spontaneous</td>\n",
+       "      <td>84.818986</td>\n",
+       "      <td>null</td>\n",
+       "      <td>null</td>\n",
+       "      <td>null</td>\n",
+       "      <td>60.066770</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>null</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>null</td>\n",
+       "      <td>45</td>\n",
+       "      <td>[3644.93333333, 3644.93333333]</td>\n",
+       "      <td>[-30.0, 40.0]</td>\n",
+       "      <td>[20.0, 20.0]</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>84.818986</td>\n",
+       "      <td>0</td>\n",
+       "      <td>gabors</td>\n",
+       "      <td>85.052505</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.233520</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>null</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>null</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[3644.93333333, 3644.93333333]</td>\n",
+       "      <td>[-30.0, 40.0]</td>\n",
+       "      <td>[20.0, 20.0]</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>85.052505</td>\n",
+       "      <td>0</td>\n",
+       "      <td>gabors</td>\n",
+       "      <td>85.302704</td>\n",
+       "      <td>4</td>\n",
+       "      <td>20</td>\n",
+       "      <td>40</td>\n",
+       "      <td>0.250199</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>null</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>null</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[3644.93333333, 3644.93333333]</td>\n",
+       "      <td>[-30.0, 40.0]</td>\n",
+       "      <td>[20.0, 20.0]</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>85.302704</td>\n",
+       "      <td>0</td>\n",
+       "      <td>gabors</td>\n",
+       "      <td>85.552904</td>\n",
+       "      <td>4</td>\n",
+       "      <td>-40</td>\n",
+       "      <td>40</td>\n",
+       "      <td>0.250199</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>null</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>null</td>\n",
+       "      <td>90</td>\n",
+       "      <td>[3644.93333333, 3644.93333333]</td>\n",
+       "      <td>[-30.0, 40.0]</td>\n",
+       "      <td>[20.0, 20.0]</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>85.552904</td>\n",
+       "      <td>0</td>\n",
+       "      <td>gabors</td>\n",
+       "      <td>85.803103</td>\n",
+       "      <td>4</td>\n",
+       "      <td>10</td>\n",
+       "      <td>30</td>\n",
+       "      <td>0.250199</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         color contrast frame orientation  \\\n",
+       "stimulus_presentation_id                                    \n",
+       "0                         null     null  null        null   \n",
+       "1                         null      0.8  null          45   \n",
+       "2                         null      0.8  null           0   \n",
+       "3                         null      0.8  null           0   \n",
+       "4                         null      0.8  null          90   \n",
+       "\n",
+       "                                                   phase            pos  \\\n",
+       "stimulus_presentation_id                                                  \n",
+       "0                                                   null           null   \n",
+       "1                         [3644.93333333, 3644.93333333]  [-30.0, 40.0]   \n",
+       "2                         [3644.93333333, 3644.93333333]  [-30.0, 40.0]   \n",
+       "3                         [3644.93333333, 3644.93333333]  [-30.0, 40.0]   \n",
+       "4                         [3644.93333333, 3644.93333333]  [-30.0, 40.0]   \n",
+       "\n",
+       "                                  size spatial_frequency  start_time  \\\n",
+       "stimulus_presentation_id                                               \n",
+       "0                                 null              null   24.752216   \n",
+       "1                         [20.0, 20.0]              0.08   84.818986   \n",
+       "2                         [20.0, 20.0]              0.08   85.052505   \n",
+       "3                         [20.0, 20.0]              0.08   85.302704   \n",
+       "4                         [20.0, 20.0]              0.08   85.552904   \n",
+       "\n",
+       "                         stimulus_block stimulus_name  stop_time  \\\n",
+       "stimulus_presentation_id                                           \n",
+       "0                                  null   spontaneous  84.818986   \n",
+       "1                                     0        gabors  85.052505   \n",
+       "2                                     0        gabors  85.302704   \n",
+       "3                                     0        gabors  85.552904   \n",
+       "4                                     0        gabors  85.803103   \n",
+       "\n",
+       "                         temporal_frequency x_position y_position   duration  \\\n",
+       "stimulus_presentation_id                                                       \n",
+       "0                                      null       null       null  60.066770   \n",
+       "1                                         4          0         10   0.233520   \n",
+       "2                                         4         20         40   0.250199   \n",
+       "3                                         4        -40         40   0.250199   \n",
+       "4                                         4         10         30   0.250199   \n",
+       "\n",
+       "                          stimulus_condition_id  \n",
+       "stimulus_presentation_id                         \n",
+       "0                                             0  \n",
+       "1                                             1  \n",
+       "2                                             2  \n",
+       "3                                             3  \n",
+       "4                                             4  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# this can be slow depending on the size of the data\n",
+    "presentation_table = session.stimulus_presentations\n",
+    "presentation_table.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Included is metadata about each unit, as a pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>waveform_duration</th>\n",
+       "      <th>firing_rate</th>\n",
+       "      <th>waveform_PT_ratio</th>\n",
+       "      <th>d_prime</th>\n",
+       "      <th>waveform_recovery_slope</th>\n",
+       "      <th>waveform_velocity_below</th>\n",
+       "      <th>presence_ratio</th>\n",
+       "      <th>L_ratio</th>\n",
+       "      <th>waveform_amplitude</th>\n",
+       "      <th>max_drift</th>\n",
+       "      <th>...</th>\n",
+       "      <th>ecephys_structure_id</th>\n",
+       "      <th>ecephys_structure_acronym</th>\n",
+       "      <th>anterior_posterior_ccf_coordinate</th>\n",
+       "      <th>dorsal_ventral_ccf_coordinate</th>\n",
+       "      <th>left_right_ccf_coordinate</th>\n",
+       "      <th>probe_description</th>\n",
+       "      <th>location</th>\n",
+       "      <th>probe_sampling_rate</th>\n",
+       "      <th>probe_lfp_sampling_rate</th>\n",
+       "      <th>probe_has_lfp_data</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>unit_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>951853174</th>\n",
+       "      <td>0.219765</td>\n",
+       "      <td>19.441146</td>\n",
+       "      <td>0.199007</td>\n",
+       "      <td>6.714259</td>\n",
+       "      <td>-0.049973</td>\n",
+       "      <td>0.206030</td>\n",
+       "      <td>0.99</td>\n",
+       "      <td>0.000089</td>\n",
+       "      <td>84.471855</td>\n",
+       "      <td>48.84</td>\n",
+       "      <td>...</td>\n",
+       "      <td>215.0</td>\n",
+       "      <td>APN</td>\n",
+       "      <td>7928</td>\n",
+       "      <td>3129</td>\n",
+       "      <td>7167</td>\n",
+       "      <td>probeA</td>\n",
+       "      <td></td>\n",
+       "      <td>29999.96621</td>\n",
+       "      <td>1249.998592</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>951853190</th>\n",
+       "      <td>0.137353</td>\n",
+       "      <td>10.267881</td>\n",
+       "      <td>0.734993</td>\n",
+       "      <td>2.744475</td>\n",
+       "      <td>-0.154760</td>\n",
+       "      <td>-0.431682</td>\n",
+       "      <td>0.99</td>\n",
+       "      <td>0.137435</td>\n",
+       "      <td>95.045925</td>\n",
+       "      <td>50.17</td>\n",
+       "      <td>...</td>\n",
+       "      <td>215.0</td>\n",
+       "      <td>APN</td>\n",
+       "      <td>7908</td>\n",
+       "      <td>3068</td>\n",
+       "      <td>7169</td>\n",
+       "      <td>probeA</td>\n",
+       "      <td></td>\n",
+       "      <td>29999.96621</td>\n",
+       "      <td>1249.998592</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>951853197</th>\n",
+       "      <td>0.151089</td>\n",
+       "      <td>10.161642</td>\n",
+       "      <td>0.625356</td>\n",
+       "      <td>3.389818</td>\n",
+       "      <td>-0.102740</td>\n",
+       "      <td>-0.343384</td>\n",
+       "      <td>0.99</td>\n",
+       "      <td>0.073114</td>\n",
+       "      <td>73.191495</td>\n",
+       "      <td>47.14</td>\n",
+       "      <td>...</td>\n",
+       "      <td>215.0</td>\n",
+       "      <td>APN</td>\n",
+       "      <td>7905</td>\n",
+       "      <td>3060</td>\n",
+       "      <td>7169</td>\n",
+       "      <td>probeA</td>\n",
+       "      <td></td>\n",
+       "      <td>29999.96621</td>\n",
+       "      <td>1249.998592</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>951853216</th>\n",
+       "      <td>0.563149</td>\n",
+       "      <td>6.664585</td>\n",
+       "      <td>0.645313</td>\n",
+       "      <td>5.647242</td>\n",
+       "      <td>-0.024678</td>\n",
+       "      <td>0.286153</td>\n",
+       "      <td>0.99</td>\n",
+       "      <td>0.009056</td>\n",
+       "      <td>45.769815</td>\n",
+       "      <td>32.12</td>\n",
+       "      <td>...</td>\n",
+       "      <td>215.0</td>\n",
+       "      <td>APN</td>\n",
+       "      <td>7866</td>\n",
+       "      <td>2948</td>\n",
+       "      <td>7168</td>\n",
+       "      <td>probeA</td>\n",
+       "      <td></td>\n",
+       "      <td>29999.96621</td>\n",
+       "      <td>1249.998592</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>951853225</th>\n",
+       "      <td>0.576884</td>\n",
+       "      <td>9.174408</td>\n",
+       "      <td>0.558268</td>\n",
+       "      <td>4.388771</td>\n",
+       "      <td>-0.033880</td>\n",
+       "      <td>0.073582</td>\n",
+       "      <td>0.99</td>\n",
+       "      <td>0.017206</td>\n",
+       "      <td>57.620160</td>\n",
+       "      <td>38.75</td>\n",
+       "      <td>...</td>\n",
+       "      <td>215.0</td>\n",
+       "      <td>APN</td>\n",
+       "      <td>7854</td>\n",
+       "      <td>2913</td>\n",
+       "      <td>7167</td>\n",
+       "      <td>probeA</td>\n",
+       "      <td></td>\n",
+       "      <td>29999.96621</td>\n",
+       "      <td>1249.998592</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 89 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           waveform_duration  firing_rate  waveform_PT_ratio   d_prime  \\\n",
+       "unit_id                                                                  \n",
+       "951853174           0.219765    19.441146           0.199007  6.714259   \n",
+       "951853190           0.137353    10.267881           0.734993  2.744475   \n",
+       "951853197           0.151089    10.161642           0.625356  3.389818   \n",
+       "951853216           0.563149     6.664585           0.645313  5.647242   \n",
+       "951853225           0.576884     9.174408           0.558268  4.388771   \n",
+       "\n",
+       "           waveform_recovery_slope  waveform_velocity_below  presence_ratio  \\\n",
+       "unit_id                                                                       \n",
+       "951853174                -0.049973                 0.206030            0.99   \n",
+       "951853190                -0.154760                -0.431682            0.99   \n",
+       "951853197                -0.102740                -0.343384            0.99   \n",
+       "951853216                -0.024678                 0.286153            0.99   \n",
+       "951853225                -0.033880                 0.073582            0.99   \n",
+       "\n",
+       "            L_ratio  waveform_amplitude  max_drift  ...  ecephys_structure_id  \\\n",
+       "unit_id                                             ...                         \n",
+       "951853174  0.000089           84.471855      48.84  ...                 215.0   \n",
+       "951853190  0.137435           95.045925      50.17  ...                 215.0   \n",
+       "951853197  0.073114           73.191495      47.14  ...                 215.0   \n",
+       "951853216  0.009056           45.769815      32.12  ...                 215.0   \n",
+       "951853225  0.017206           57.620160      38.75  ...                 215.0   \n",
+       "\n",
+       "           ecephys_structure_acronym  anterior_posterior_ccf_coordinate  \\\n",
+       "unit_id                                                                   \n",
+       "951853174                        APN                               7928   \n",
+       "951853190                        APN                               7908   \n",
+       "951853197                        APN                               7905   \n",
+       "951853216                        APN                               7866   \n",
+       "951853225                        APN                               7854   \n",
+       "\n",
+       "           dorsal_ventral_ccf_coordinate  left_right_ccf_coordinate  \\\n",
+       "unit_id                                                               \n",
+       "951853174                           3129                       7167   \n",
+       "951853190                           3068                       7169   \n",
+       "951853197                           3060                       7169   \n",
+       "951853216                           2948                       7168   \n",
+       "951853225                           2913                       7167   \n",
+       "\n",
+       "           probe_description  location  probe_sampling_rate  \\\n",
+       "unit_id                                                       \n",
+       "951853174             probeA                    29999.96621   \n",
+       "951853190             probeA                    29999.96621   \n",
+       "951853197             probeA                    29999.96621   \n",
+       "951853216             probeA                    29999.96621   \n",
+       "951853225             probeA                    29999.96621   \n",
+       "\n",
+       "           probe_lfp_sampling_rate  probe_has_lfp_data  \n",
+       "unit_id                                                 \n",
+       "951853174              1249.998592                True  \n",
+       "951853190              1249.998592                True  \n",
+       "951853197              1249.998592                True  \n",
+       "951853216              1249.998592                True  \n",
+       "951853225              1249.998592                True  \n",
+       "\n",
+       "[5 rows x 89 columns]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "session.units.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Spike times are stored in a dictionary, with the unit IDs as keys and arrays for the spike times."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n",
+      "[call_caching INFO] Reading data from cache\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([3.79479685e+00, 3.80853020e+00, 3.80933020e+00, ...,\n",
+       "       9.62280203e+03, 9.62339993e+03, 9.62352627e+03])"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# this is a large dict, so let's just look at one key\n",
+    "session.spike_times[951853174]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loading existing NWB files with session"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you've previously downloaded data, you can avoid the cache creation and just create a session from an NWB file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nwb_filepath = Path(r'/auto/users/tomlinsa/code/allen/data/session_760345702/session_760345702.nwb')\n",
+    "assert nwb_filepath.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session = EcephysSession.from_nwb_path(str(nwb_filepath), api_kwargs={\n",
+    "        \"amplitude_cutoff_maximum\": np.inf,\n",
+    "        \"presence_ratio_minimum\": -np.inf,\n",
+    "        \"isi_violations_maximum\": np.inf\n",
+    "    })"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# session.stimulus_presentations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# or from NWB file (preffered)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the raw data. The session method of getting the data does it's own formatting of the dataframes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nwb_filepath = Path(r'/auto/users/tomlinsa/code/allen/data/session_760345702/session_760345702.nwb')\n",
+    "assert nwb_filepath.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "io = NWBHDF5IO(str(nwb_filepath), 'r')\n",
+    "nwbfile = io.read()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'metadata': \n",
+       " metadata <class 'allensdk.brain_observatory.ecephys.nwb.EcephysLabMetaData'>\n",
+       " Fields:\n",
+       "   age_in_days: 103.0\n",
+       "   full_genotype: Pvalb-IRES-Cre/wt;Ai32(RCL-ChR2(H134R)_EYFP)/wt\n",
+       "   sex: M\n",
+       "   specimen_name: Pvalb-IRES-Cre;Ai32-407972\n",
+       "   stimulus_name: brain_observatory_1.1\n",
+       "   strain: C57BL/6J}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nwbfile.lab_meta_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The rest of the attributes are still accessible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# nwbfile.units\n",
+    "# nwbfile.epochs\n",
+    "# nwbfile.stimulus_presentations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load into NEMS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nems.recording INFO] Loading NWB file with format \"neuropixel\" from \"/auto/users/tomlinsa/code/allen/data/session_760345702/session_760345702.nwb\".\n",
+      "[nems.recording INFO] Successfully loaded nwb file.\n"
+     ]
+    }
+   ],
+   "source": [
+    "r = Recording.from_nwb(nwb_filepath, 'neuropixel')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All of the usual attributes are accessible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>start</th>\n",
+       "      <th>end</th>\n",
+       "      <th>name</th>\n",
+       "      <th>stimulus_block</th>\n",
+       "      <th>temporal_frequency</th>\n",
+       "      <th>x_position</th>\n",
+       "      <th>y_position</th>\n",
+       "      <th>color</th>\n",
+       "      <th>colorSpace</th>\n",
+       "      <th>depth</th>\n",
+       "      <th>...</th>\n",
+       "      <th>tex</th>\n",
+       "      <th>texRes</th>\n",
+       "      <th>units</th>\n",
+       "      <th>stimulus_index</th>\n",
+       "      <th>orientation</th>\n",
+       "      <th>spatial_frequency</th>\n",
+       "      <th>frame</th>\n",
+       "      <th>contrast</th>\n",
+       "      <th>flipHoriz</th>\n",
+       "      <th>flipVert</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>24.752216</td>\n",
+       "      <td>84.818986</td>\n",
+       "      <td>spontaneous</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td></td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>84.818986</td>\n",
+       "      <td>85.052505</td>\n",
+       "      <td>gabors</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>[1.0, 1.0, 1.0]</td>\n",
+       "      <td>rgb</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>sin</td>\n",
+       "      <td>256.0</td>\n",
+       "      <td>deg</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>45.0</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>85.052505</td>\n",
+       "      <td>85.302704</td>\n",
+       "      <td>gabors</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>[1.0, 1.0, 1.0]</td>\n",
+       "      <td>rgb</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>sin</td>\n",
+       "      <td>256.0</td>\n",
+       "      <td>deg</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>85.302704</td>\n",
+       "      <td>85.552904</td>\n",
+       "      <td>gabors</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>-40.0</td>\n",
+       "      <td>40.0</td>\n",
+       "      <td>[1.0, 1.0, 1.0]</td>\n",
+       "      <td>rgb</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>sin</td>\n",
+       "      <td>256.0</td>\n",
+       "      <td>deg</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>85.552904</td>\n",
+       "      <td>85.803103</td>\n",
+       "      <td>gabors</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>[1.0, 1.0, 1.0]</td>\n",
+       "      <td>rgb</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>sin</td>\n",
+       "      <td>256.0</td>\n",
+       "      <td>deg</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>90.0</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 27 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       start        end         name  stimulus_block  temporal_frequency  \\\n",
+       "0  24.752216  84.818986  spontaneous             NaN                 NaN   \n",
+       "1  84.818986  85.052505       gabors             0.0                 4.0   \n",
+       "2  85.052505  85.302704       gabors             0.0                 4.0   \n",
+       "3  85.302704  85.552904       gabors             0.0                 4.0   \n",
+       "4  85.552904  85.803103       gabors             0.0                 4.0   \n",
+       "\n",
+       "   x_position  y_position            color colorSpace  depth  ...  tex texRes  \\\n",
+       "0         NaN         NaN                                NaN  ...         NaN   \n",
+       "1         0.0        10.0  [1.0, 1.0, 1.0]        rgb    0.0  ...  sin  256.0   \n",
+       "2        20.0        40.0  [1.0, 1.0, 1.0]        rgb    0.0  ...  sin  256.0   \n",
+       "3       -40.0        40.0  [1.0, 1.0, 1.0]        rgb    0.0  ...  sin  256.0   \n",
+       "4        10.0        30.0  [1.0, 1.0, 1.0]        rgb    0.0  ...  sin  256.0   \n",
+       "\n",
+       "   units stimulus_index orientation spatial_frequency frame contrast  \\\n",
+       "0                   NaN         NaN                     NaN      NaN   \n",
+       "1    deg            0.0        45.0              0.08   NaN      0.8   \n",
+       "2    deg            0.0         0.0              0.08   NaN      0.8   \n",
+       "3    deg            0.0         0.0              0.08   NaN      0.8   \n",
+       "4    deg            0.0        90.0              0.08   NaN      0.8   \n",
+       "\n",
+       "   flipHoriz flipVert  \n",
+       "0        NaN      NaN  \n",
+       "1        NaN      NaN  \n",
+       "2        NaN      NaN  \n",
+       "3        NaN      NaN  \n",
+       "4        NaN      NaN  \n",
+       "\n",
+       "[5 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r.epochs.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'specimen_name': 'Pvalb-IRES-Cre;Ai32-407972',\n",
+       " 'age_in_days': 103.0,\n",
+       " 'full_genotype': 'Pvalb-IRES-Cre/wt;Ai32(RCL-ChR2(H134R)_EYFP)/wt',\n",
+       " 'strain': 'C57BL/6J',\n",
+       " 'sex': 'M',\n",
+       " 'stimulus_name': 'brain_observatory_1.1',\n",
+       " 'uri': '/auto/users/tomlinsa/code/allen/data/session_760345702/session_760345702.nwb'}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r.meta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All of the spike times are saved into a single `PointProcess` signal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'session_760345702': <nems.signal.PointProcess at 0x7fd3ea723f98>}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r.signals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1784"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "signal = r.signals['session_760345702']\n",
+    "signal.nchans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each channel key is the unit ID from the units dataframe of the NWB file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([  10.2351168 ,   11.66955413,   11.69268753, ..., 9612.18553725,\n",
+       "       9612.20010396, 9620.83476135])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# ex, unit 951843010\n",
+    "signal._data[951843010]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `units` metadata is saved into the meta of the signal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'waveform_duration': 0.755443886097152,\n",
+       " 'firing_rate': 1.74113707219344,\n",
+       " 'PT_ratio': 0.00729943086142739,\n",
+       " 'd_prime': nan,\n",
+       " 'recovery_slope': -0.00895206089461061,\n",
+       " 'quality': 'noise',\n",
+       " 'velocity_below': 1.03015075376884,\n",
+       " 'presence_ratio': 0.99,\n",
+       " 'l_ratio': 0.0,\n",
+       " 'amplitude': 51.4938450000001,\n",
+       " 'max_drift': 23.6,\n",
+       " 'snr': 1.92770330724404,\n",
+       " 'nn_hit_rate': nan,\n",
+       " 'spread': 60.0,\n",
+       " 'nn_miss_rate': nan,\n",
+       " 'cumulative_drift': 615.49,\n",
+       " 'waveform_halfwidth': 0.357118927973199,\n",
+       " 'isolation_distance': nan,\n",
+       " 'isi_violations': 1.06689648479891,\n",
+       " 'silhouette_score': 0.0759991877886951,\n",
+       " 'local_index': 263,\n",
+       " 'amplitude_cutoff': 0.268061054461112,\n",
+       " 'repolarization_slope': 0.122863156143529,\n",
+       " 'cluster_id': 267,\n",
+       " 'velocity_above': 1.37353433835846,\n",
+       " 'peak_channel_id': 850096152}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# ex, unit 951843010\n",
+    "signal.meta[951843010]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Get stimulus images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, frame 78 from `natural_scenes`, as in this random row:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>start</th>\n",
+       "      <th>end</th>\n",
+       "      <th>name</th>\n",
+       "      <th>frame</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>51357</th>\n",
+       "      <td>5910.169789</td>\n",
+       "      <td>5910.420001</td>\n",
+       "      <td>natural_scenes</td>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             start          end            name  frame\n",
+       "51357  5910.169789  5910.420001  natural_scenes  100.0"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r.epochs.loc[[51357], ['start', 'end', 'name', 'frame']]  # list iloc to keep as df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[call_caching INFO] Reading data from cache\n"
+     ]
+    }
+   ],
+   "source": [
+    "im = cache.get_natural_scene_template(100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7fd3ea60bf60>"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAT4AAAD8CAYAAADub8g7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8li6FKAAAgAElEQVR4nOydf3DT95nnX7JlSbZlCduSjZEMjkVCLRJiuyF2WmrTEmDLYraZ0FsKmebCTXtJrtlmZ9Mf1+vl2js6k+boZbdMm3RzJelsQ7O34ZIGQosZNgchxQ6JbSDI4FjGPyT8Q7KFJP/QV7bs+8P3PMhptnNzc73LzPKZyQTb0vfH58fzeT/v5/08H9PCwgI32812s91s/5xazv/vB7jZbrab7Wb7f91uGr6b7Wa72f7ZtZuG72a72W62f3btpuG72W62m+2fXbtp+G62m+1m+2fXbhq+m+1mu9n+2bU/iuEzmUx/YjKZrphMpl6TyfTtP8Y9brab7Wa72f5Pm+n/to7PZDLlAj3AZiAEnAO+tLCwEPi/eqOb7Wa72W62/8P2x0B8dwO9CwsLfQsLC2ngZeDP/gj3udlutpvtZvs/auY/wjU9wFDWzyGg4cMfMplMXwW+CpCXl/fJFStW4HK59O+jo6NYrVaWLVsGQDKZZHJykvz8fOx2O/F4nLm5ORwOByaTienpaXJyFu14bm6u3AObzcbc3BxTU1NYrVZSqRSzs7MAWK1WcnJyyGQyWCwWzGYzubm5TE9PMz09jdvtJi8vT58pHA4zPz8PQCqVoqysjOnpaebm5shkMuTl5TE9Pf3h96SgoIDly5cTCoX02ex2OxMTE8zNzZGbm0teXh45OTmYTCYMw2BhYYFMJsPs7Kz+PZPJUFhYyNzcHPPz8xQUFOB2uzEMg3g8ztTUFOl0mrm5OUwmE5lMhtzcXKxWK/n5+eTn5zM7O8v8/DwLCwuYTCZyc3P1M5lMhsnJSWw2GwsLC1itVubn50mlUiSTSX2m+fl5cnJymJubA9A+kb5fWFggLy9P+7mwsBDDMLSfDcPQz0u/5ebm6nvLc5lMJnJycvR5i4uLKSsr03uMjIyQTCbJzc0lPz9fnwsgPz+fmZkZMpkM6XQagJycHL2XvN/MzIx+Z35+nvz8fNLptPbH1NQUmUyGhYUFCgoKyMnJIScnB5vNRiKRYG5uDrPZrO88Pz9POp3GZDKxsLCAYRhL5qPVagVgdnYWk8mExWLBarViMpl03KQfs/sgJyeHmZkZZmZmtF8zmYxe12KxkJubq+9qNpuxWCwkEgkKCwv1HjKGhYWFFBYWfnhZMjU19ZG/lzUpYyfvbDKZ9LqpVAqbzUZhYaHOtex5IO9tNpuxWq3k5uZq/8t8NplMS95P5tv8/Lyuh7m5OWZnZykoKNCxMZvNGIahc1LW8eTkpOmj3uWPYfj+t9rCwsLfAn8L8IlPfGLh3/ybf4NhGDzxxBMAnDt3Dp/PRygUor29nWAwyNjYGACPPPIIXV1dBAIB/H4/tbW1BAIBhoaGGB8fx2q1YrfbAVi9ejVNTU288cYbFBUVEYlEiEQipNNpmpqa2LJlC2NjYzgcDk6cOEEoFCIcDrN9+3Y2bNjA5OQk7e3tRCIRTp06hdPpxG6389Zbb/GZz3yGyspKgsEgyWSSeDxONBrFMAysViuGYeDxeLBarbjdbiKRCOFwmJaWFoaGhgiFQkSjUXw+nz5zX18fqVQKWDS0hmFgGAZlZWVUV1fjdDoBMAyDoqIivvnNb3L06FFCoRCnT58mGAwuMSwul4vKykqKioqwWq34fD4SiQQWiwWAyclJALZv347b7aazs5NIJEJnZyfNzc2k02nte7l2MpnE5XLpsyWTSb2fvLf8H2Dnzp0MDg7S3d1NOp1e8nzSR/I7+btcw2q1YrFYSKfTeL1efvazn+FwODh16hShUIi+vj6CwSB+vx+fz0c8Htc+Gh0d1f50Op243W58Ph9DQ0OEw2EdS4Dvfve7PPLIIzQ3N5NMJhkdHaWyspLjx48DMD4+rn2UTCZ1zkUiEYLBID6fj1QqxeTkpM6DvLw83nnnHTweD06nE6vVSlFREXV1dUQiERwOB263m3Q6TTwex+12q2E0DINIJKI/AwQCAeLxuBoUeYfa2lr8fj9+vx/DMDhy5Ih+JxKJ8Oyzz3LmzBlqa2v1fT+qXbt2jRUrVnzk7w8ePPh7fSnNYrFgs9no6Oigvr4er9dLY2MjiURCx1fms4yVw+HAYrEQDocB8Hg8lJWVkUqlSCQSANhsNv1MIBDg0qVLhMNhvV59fT2RSETnjYz3t771LXw+Hw0Nv4e3tP0xDF8YqMz62fu/fvdPNsMwcDgcJBIJ9u/fz969e1m/fj39/f062LIzGoZBIBCgpqaGVCpFPB7X709OTjI6Oorf78dms5FKpQiFQnR1dbF582Y6OzsxDIOdO3cC4Pf7AWhvbyeRSOhAPfXUUwCcPHmSs2fP8sUvfpFAILBksK1WK4FAgMrKSn02QNFoPB4HwOFwEAwG2bx5M7BoiGpqaujo6ABg8+bN9PX1UVNTw9DQIlB2Op1Eo1E8Hg99fX0AS4xqWVkZ//7f/3tOnTpFd3c3vb29+hkxIGKcsp83HA5rv9hsNkpLSzEMg1QqhWEYtLW1kUgkCAQCVFdXMzQ0RDqdxmKxkEwmaW5u5siRI1gsFn0ueUeZrHIveQ7DMNRwioGU/xcVFZFOp3XyNzY20tvbSyKRIJ1Ok06nSSaTuhjHxsZ47rnnljyzGPOmpiYSiQTxeJzR0VHGx8cpLS0llUoxPj7O6tWrcTgcdHd3q5GR9uijj2r/BQIB0uk0g4OD2Gw2YHEBymLz+/1EIhFCoRDNzc185zvfYXJyEr/fj9VqVcScl5enm0p2X+Tl5RGJRBSpy4Yo8w8gFArh9Xrx+/36OdkEnU4nNpsNv9/P0NAQFotFDUAkEmHTpk1YrVYSiQRWq5VIJMLc3NwSMPBR7eTJk2zatOn3fn/gwAHOnj1LeXk51dXVAIoqAdxuN263m1AotORnMUiyUcgm5nA4cDgcOg9kDNPptF7D4XBQUlKi9ygqKtL7RqNR3G63Glafz0cwGKSoqIivfOUrnDlzBljcJAQ9f1T7Yxi+c8CtJpPpFhYN3i5g9x/6wsLCAul0Gp/Ph9vt5umnn+app56iqqqKzs5ONQJutxubzUYkEsHr9WKz2ZZ0vGEYS2A1QCKRIBgM4vV6aWlp4dSpU8DiJHz22WcBdCI2Njayfv16AM6cOcMrr7wCLA5eIBCgubmZ1tZWqqur1bhlGzyZ4DabTQcUFg3Z+Pg4Ho+HRx99lK997Ws4nU7KyspwOBx4PB6GhoYIBALMzs7idDoZGxvD5/PhdDr1PrJwGhoa+Jf/8l+ye/du2traSKfTRCIRbDabfk4mi9Pp1H97PB6dXF6vl8rKSjZu3KjoIhgMEgqFcDqdrF27lkuXLtHb26sIqqurC1icmNkGMRqNKipzOBwYhoHL5SIcDpNOp0kkEng8HjXc8tlsAykIPC8vT5GhXFdaMpkkGAwq/TA+Pq6Ug6Cc+vp6nE4nk5OTpNNpVq9erc8fDAYVXUYiEQzDYMuWLSQSCZ544gnq6+uBRRrjnnvuwWazUV5ezujoKOXl5TQ3N6txCgaDtLa2Mj4+rhtpUVER4XBYN5ZwOKxzwOVykUqlKC8vx+126+IPBoP09fURCoUYGxvDZrMRCoUoKysjFArp3PR4PDQ3N7N582bdCM6cOcNLL73E+Pg4mzdvVmOzbt06YBGpyfyXef1R7aOMXn9/P52dnZw9e5bZ2dklyFPGXuaSbG4AQ0NDNDc3Y7FY6O7uBsDn8y25thj67DUiCDgUClFTU6ObhmyAp0+fBtCx9/v9ukk/+OCDem2r1UpbWxuHDx9WQPBR7f+64VtYWJgzmUxfA44DucDBhYWFS3/oO4WFhTQ0NOByuUgmk9jtdvbv38/jjz/Offfdh9VqJRgMEo/H8Xq9wOLiq62t1Z1SBl0WnOzWRUVFOBwOIpEIZrOZmpoaurq6dLeQ795///06oU6ePMmpU6fUbTp48CBOpxOHw0E0GmXPnj289dZbijrKy8sZGhqiqKiI0dFRSktLFfHJM42OjuLxeDhy5Aizs7MYhqFu19q1a2lvb2dyclJ3xrKyMgBFLU6nE5fLRXNzM6dPn8bj8agRF+Mo98xGe/L9ZDKJz+dT4yPGNp1O89BDD5FKpejt7SWVSuH1erFarYyPj1NeXk5TUxP/8A//oIhUEJogM4vFgsvl4tq1awCKUKxWqy54p9Op/J7VasXj8ZBMJhUtWiwWTpw4QUtLC319fVy7dk0NpCAMl8ulnJFcJ5VKMTQ0pAtC0N7o6Cj19fXs3LmTEydOKH0gBtdqtSqyP3DgAFu2bMHr9dLW1saOHTt0Pgkyb2hoWLKJhsNhotEopaWlBAIBGhoa1BDE43FWr16tSETcXHlv4Qfj8Th9fX1qLMXFd7lcnD17Fp/PR11dHV1dXcTjcR5//HGd1wAbNmxQj0YAgBixc+fO6T3XrFmj35mcnPw95BeJRNi6daui2rq6Ojo7O7FarZSXl6urPjQ0hMPhWLK+5Gen06nAJZFIsG7dOhwOB7/61a9wu91UVVXp50OhkBq87E1ANpVkMqmbqLi+qVSKaDSq1E0wGGTTpk1LjHx7ezunT5/m7NmzGIaxBJl+uP1ROL6FhYVjwLH/3c/n5+fjcDjo6urSzgZ47LHH2LNnD9u2baO/v5/nnnsOWOQUTp06xRNPPMGrr77KiRMn1N3p7OwknU5jt9uprKxUV1N2JK/Xq/+Wn3ft2gXAsWOLj2wYBr29vdhsNvbu3cvhw4fx+Xx0dHSwefNmzp49y9jYGJWVlQwNDeF0OpWbKi8vp6ioiMnJSZ3EHo+Hd955h3A4TCKRwOVyYbPZaG1txefz0d7eTm1trXJohmHg9Xqprq7WBTg+Pk44HObo0aMAagDuvPNOJicn9X6A8m9FRUWMj4/rRB4bG6OoqEjfpb6+nkAgwLPPPktdXR07duygsrKSrq4ugsGgGq5QKMTk5CSVlZW6i8qiEpcqnU5TVFREIpFQY5ZMJnXhC2qVfhI0KM1isTA0NMTo6CjV1dXKHQoXJG6vcGiC4pxOp46nzWYjEAioK/jEE09w5swZ7UeHw8HQ0BB79uyhra2NkydPav/6fD4ikQgtLS3KBctcmJycVANz//33E4lEKCoqIi8vT+mSUChEIpFgcHBQN4yysjKGhob4zGc+w+rVq3VjiUaj+jnpF9koLBaLbk7CX4rhlHns8/nUmAlqfvbZZ3XDa2howO12EwwGl1AQwO8ZvXPnztHb20tpaSnV1dVs3LhR3Xh5t66uLnWrg8GgPp+4mU6nk4aGBhoaGtQju3DhAl6vF4/HQyAQUB5QKIZsT03mvXDhhmEooBFkHQ6Hlc64//77l7jCsLgZHzlyhLKyMu33P9Ryv/e97/3BD/y/aM8999z3Pv3pTxMKhXQH+NSnPoXNZuO3v/0tMzMz6noMDg5SUFCA1+vl1ltvpby8nGPHjpGTk8Pq1auXRIcymQxer5f333+f4uJiSkpKGBgYoKSkBKvVypYtW1izZg3Xrl3jxRdfZGZmRgMfFRUVzM/Pk0gkKCsrIx6PMz09TWlpKXa7nVgshtlspqqqiqqqKhwOB/39/axatUpdlfn5eQzD4PLlyxQWFmKxWBgeHmbZsmWkUilyc3MZHx/H7/ezYcMGhoeHGRkZ0YiyGGBYjDhKxK2oqIiZmRmNBE9NTRGNRhkZGeH69esaaXQ4HNhsNm699VaNAAIUFxdjt9vp7+/H4/FQWVmpSHrNmjW43W7a29sxm80aaS4uLqavr4+5uTnuuusuIpEIubm5el2z2czy5csZHR1VTslqtZJMJrXfTCYTqVRqCfdSUFAA3OCNmpubCYVC6uoahsH09LQGBsrLy6msrMRqtWqUVaKpxcXF+Hw+NmzYwJ49e5icnCQQCGC1WonFYlitVh599FGuXbvG9PQ0kUiEwsJCgsEgFRUVxGIxRkZGiMViZDIZYrEYly5dUs7tC1/4AoFAgKqqKjKZDCaTicLCQnp6eujr68MwDGZmZnQBz83N4Xa7KS4uVqXA9evXuXjxIjMzM4rQV61apQglk8mwfPlyMpmMRj5XrVpFNBolmUzi9XpJJBIa4S0sLMTn82EYBmvXruVzn/sc7777LrW1tXq9lStXLol4Szt58qTy3k6nkxUrVhAKhVi/fj0lJSUEg0EymQwOhwO/34/ZbKanp0ejuQsLC6pO2LRpEw6Hg5GRETKZDIlEgs7OThKJBBcvXmR6ehqPx4PJZCKRSFBSUsLCwoKOS3YkWebUwMAAwWCQWCxGXV0dDz/8MFu3biU/Px9YRHnnz5/n+vXrDAwMMDAwQF9fH1arlbm5OUZHR/nOd77z/Y+yOf/forrZTUjOzZs3093djdVqJRqNEo1GKSoqorW1FYfDwaZNm9Q1FXRTUlJCS0uL7pDiMkSjUWpra5UfgRs8QkNDwxK39ujRo+qeOp1OqqursVqt1NXV6b0l+ir8TVFRkbpwfr+f1tZW5QKdTqe6VhJlFk6jtrZWryfIJxAIKOfW3t6ubkA6nVZkY7PZGBsbY2xsTDkzMS7Zbq7weRLFLS0tpa+vj7KyMg0KiHtSVlaG0+nU3VZQhKA8gOPHjyuKbWhooLW1lUDghhY9m6f7MCeXzeE0NTUB8NJLLy1BevIZQYmRSITPfvaz6q5IPwlyETQlfKbFYmHlypXY7XZ9Tp/Px+nTpwmHw1gsFtxut3JjBw4cUN7MZrMRDAbV/ZIm7qzVatX7JJNJRT7y3nJtQMfXbrfj9/vVRZR3FJQ3OTmpc0g2VHHdLRaLun1FRUW6LmDRfRYVgMvlwuv1akAjkUhoMMTr9dLZ2Yndbsfr9RIKhdSzMAyDdevWce3aNX784x+rV+BwOBSViwcyOjrK5OQkLpdLaaFIJEJ1dbW6mr29vQSDQWw2G11dXRpklL6UuRGJRFQZ4fP5lAfODvrIv0OhkHppzc3NWK1WnE4nX/nKV3R89u3bp96cfFeQZzweZ3JyEqfTyR9KzvhYIL6f//zn33v88cdZsWIF1dXVmM1mpqenCQQClJWVUVBQwLFjx/jkJz/J+vXruXz5MmazmfLycjKZDGazme7ubo2uTkxM4Ha7WbduHWazGbPZzMjICHl5edx222184hOfAOAXv/gFwWAQi8VCeXk5drudgoICNVADAwMkEgnC4bBq/EZHR7njjjtIJBJkMhnVdFVUVPDBBx9gNptV7zQ5OYnZbMZut+vu7Ha7WVhYUNlMYWEhIyMjVFVVYbFYmJiYIJ1OE4vFVB9YUVHB2NiYagRFx1dWVobZbGZgYICJiQmSyaT2h8lkoqKiQq9VUFBAcXEx8/PzJJNJQqEQJSUlupgEPb3xxhv09fXxwAMPcPXqVd555x36+/tZsWIFZ86c0d04k8lQWVnJyMjIkon7YQQoKOeFF17AZDLR2tpKNBrVcRGtliCeiYkJdu7cSU9Pj2ruYrEYgHJ6a9aswWw2a/Cnv78fh8NBVVUVFRUVJBIJenp6GB8fx2Qy8cUvfpGioiKuXLmi3JygHLfbrd5BJpOhuLgYWFyAggZHRkawWCzEYjHy8vJ0o4pGo1RVVdHT04PJZCI/P5+VK1dSWbkoapiammJwcJBkMsnAwAAzMzMapCsuLtb39Xq95OXlqQZO/i+azaKiIubn5xkaGuK2226jqqqK4uJilXRVVFRw6dIlfve739Hc3My7776r3obX68XtdnPx4kU2btwIwJ49e9TAisRHouOwGBGV/hgeHlYEbLVauX79OlarldHRUaampjSYGAgESCaTFBQUUFJSQiQSIZPJUFJSwujoqM7RVCpFVVUVZrOZwsJCva64rm+//TZHjx6ls7OT0tJSvF4v9913HxcuXOAnP/kJP/3pTxkdHWV6eporV67Q09PDlStXmJiYwGazMTU1hcPhICcnh/7+fr71rW99fBFfPB5XpFNbW6uoT3Y1t9vNF7/4Rf7jf/yPbNmyhV27dnHmzBna2tp+L4qZHbWsqamhu7ubjo4OJicn2blzp5KsFy5c0LC7ILSWlhba2tp0YmdzJGNjYxiGQWlpKdu2baOpqYmHHnoIj8dDW1sbLS0tuFwugsEg5eXluvPE4/ElshIJ7ctuLpzL2bNn8fv9tLS0qHGQlk6nKS8vX4LcYDH6mEqlVN8on3U4HLhcLuLx+O9p5EZHR4FFjvDD0pvTp08zNDREJBKht7eXe+65h9dff50rV66oRlCIZuHoBHXCDdlGY2Oj8j+C2k+cOKF8oDT5vIyh8FtHjx5VaY7NZtOdXZBuZ2cnu3fvVrRVVFSE1+vFMAw2bNjAvn37cDqdfPe73+Xll1/mwIEDKh3JbqlUitraWtra2nA4HIryxCjIOAnygxv8aSQSIZlM0tnZqRF6i8VCZWWlSo+y+0tkSNFolJqaGmARxdfU1GCxWNRDyB5bQYWyRtLpNCdOnMDtdvPKK69gGAb79u1TTlOCONLHgkoPHz7MY489xrFjxwgEAsqVZcuwGhsbiUQiHDp0SL+XzTdXVlbqe0ikN7sfhY+DRfVAXV0dwWCQcDhMTU0NhmEQCoWUg/V6vTqu0t8nTpzgf/yP/0EymeTSpRvx0AsXLvCNb3xD57nVamVsbEwRnmxi8kzj4+MAH3/E96Mf/eh7n//854nFYnR1deH3+3XHraio4L777qOmpga73c5PfvIT7r77burr6/nd735HKBSioqKCwsJCBgYGqKioYGRkhJKSEjKZDKdOncJsNvPkk0+ybNkyXn75ZX75y18yMTFBT08PhmHQ09PD/Pw8y5cvJxgMKppoaGigp6eHZDKp7u1/+A//AYCrV6/y2muvsWbNGuXH0uk009PTmM1mVq1axcjICMuWLVMEZhgGt956K8lkkpmZGQoKCgiHw4rgCgsLaWlpobCwkOnpaaamptQVKywsJCcnR6Ukd999Nzk5OeoezszMYBiG7ni33nors7OzVFRUkJOTo66KzWajsrKSvLw81qxZQzQaJRwO09vbSywWY35+HrPZzMzMDP/4j//I6OioClK7urq4dOkShrGYhSHKeWlVVVV8/etf5+///u9VCC0ut8PhYHBwULku6WNBBtJ/DocDn89HaWmpRv8KCwuVU43FYjqhBeHdcccdxGIxNm7cyMsvv8wXvvAF7r33XhXtXr16lUAgQDAY1Ci0BEvS6TRTU1NMT08rAhkcHGRiYoLCwkJVADQ0NJCTk6Oc1OXLl7Hb7crnFRQUKOIZHR39PaNXXV2NxWKhsLCQsbExJiYmlIMeHR1l1apV6iJPTU2RTCZZtWoVBQUFzM3NkZeXx9zcnAbSzGYzW7Zs0aBSbm4uJSUlikAzmQy1tbWUlpbS0NCgqLiiooKqqir6+/uprKzEZDJxxx13EIlEePvtt1UqlkwmmZiYwOl0kkgkyMnJobu7G8MwFL0lEglsNhsTExM4HA6WLVuGYRhUVFQoZ/q5z31OM2Ak8i+0QCKRwGw2E41G+e///b9z+vRpNm7cyI9//GOWLVvGlStXePHFFzly5AihUEjRISx6FC6Xi5ycHCYmJqioqMAwDIaHhwmHwxQUFDAxMcE3vvGNj0R8HxvDt2bNGl3smzZtor6+Xhfv5cuXGR0dpba2lvfff593332XW265hU2bNjE7O8vGjRuprq6moaGB22+/nRUrVmiQYHh4mG9/e7FAzP79+wmFQlRVVTE+Pq4uprjWJpMJs9lMc3MzPT09xGIxvF4vw8PDmEwm/uqv/oq8vDz+7u/+DsMwaG9vx2azabBk+fLlJBIJdc1EbNrY2MjJkycpLy/XhT4zM0Nubq6m4EikVyZ8T08PhYWF6pZKal4qlVL9XGFhIePj48RiMf1ZWn19PW63W93JvLw8xsbG2Lp1K3V1dTQ2NlJSUkJBQQH5+fkqiZiamsLv91NcXMzU1BQWi4WLFy8qmhBjJGlusvA6Ozt56qmnuHDhghqRbCNnMplU6iAc7cjIiAYYAE2xM5vNRCIRli9frn0pgRTDMCgoKCASiWhA4+6772blypUA3H777Vy9epWf/OQnKqeIRCKasiiurqTIDQ8Pc8stt3D27FnS6TR9fX26eQwMDBCLxTRwUFFRQW9vL8XFxeoWS4rgwsICyWSS/v5+BgYGyM/Pp6SkhFgsxvT0NPn5+WpoI5EIZWVlysGNjIwwODioKGbNmjU0NjZSVVWlpL0YILPZjNfrpaCggMHBQU0/83q9FBYWcuTIEd577z3m5uZYt24d+fn5nDt3Tvt6YGAAr9dLRUUFZrOZuro6pqenef/99zl79izLli0jmUxy7do1nV8+n4++vj6cTieBQECfQzYlm83GqlWrKCwsVKNdVVXFunXrGBkZ4eLFi0xNTXH+/HkSiQSrV69Wz6utrY1Tp05x9epVLl26xJ/8yZ/w/e9/n1//+tccPXpUKazp6WnlowU9S9AtFospIi8sLNSgy+DgIN/+9rc/vobv6aef/t4dd9zBnj172LFjB3l5eYyMjHD58mVef/11NWJHjx6lra2N22+/nXfeeYd7770Xu92uUR5pLpeL9957j8bGRnbs2EF/fz//8A//sIRIj0ajinA+/elPq4ET8fHAwADpdJri4mI2bdrEzp07yc/P5zvf+Q6JREIjt8uWLdN8QskPjMViRCIRRkZGNKolecWSOXH9+nUKCgrIy8ujsLCQ3NxcSktLicViLF++XHlJydPNzc0lmUyyfv16hoeHWbFihSI8WVwS/RS92Oc//3kCgQClpaUMDg4yOztLJBLhgw8+oKuri4KCAqxWK5WVlZjNZuUECwoKMJvNqh/LFgwLqgW4fv06ZrOZN954g+3bt2s0+Ze//CWtra0avZ2enmZhYYGcnBxKSkoU7RiGoUZPdvKZmRmKiopwuVzMzc0Ri8UoLCzEbDarqzw6Oqq5mcXFxXzqU58CFqUZHo+HN998k7q6OkZGRpiamlKOTK5hGIbm0RqGQUlJCcPDwyxfvpz29nbC4bAi/es42e8AACAASURBVKKiIgYGBpibm6O/v1+j0y6Xi5KSEqLRqPKokjvscrkoLS3F7XYrF+Z0OhWlzMzMaN94PB4GBweBRcR74cIFpqamCIfDbNiwgT//8z+nu7ubDRs20NfXh8fjwWw209fXx/Lly3UzGRkZIRgMcvHiRdxutwbFVq5cya9+9Sv6+/upqKjgypUrOtbBYFB1rbAoCYnH42QyGW677TZmZ2dZtWqVbggXLlzA6XRq/rK807Jly1ixYoUaxOvXr3Pp0iWdKyaTiampKS5evKg899TUFBcuXGBgYIDm5mZefPFF9u3bx09/+lNCoZDOZ5kTU1NTujYzmYwaulgshs/nU/WB2WzGZrMp9/1PGb6PBcdXUlJCY2MjFotFuTu3282ePXt0h5FI4M6dOzEMg3feeYdjx46xbdu2j7ymqLknJiY4ceKEclviKsj1BHJL9Ki6upqzZ89SX19PR0cH8XhcVe379u1jbGxM+beWlhZGR0c1ACLEtfA1wnNJlFpIZNGn+f1+zp8/z9jYmHJ3kgq3c+dO3nzzTU1fy8vL0+hVOBxWraNEBOGG8RCuTHJXJVodjUbV8Mq7t7e3a2RPvh+NRrHb7Ro9FH5H+jA7H3ffvn00NDQoT3P//fdjtVo5duwY9913n8oLYHERDg4OLulzeUbpU3n27HQxeRbRwBUVFWEYBmNjYxphPnfuHIlEgn379ml+NSwKuGXM4YbAXWREEtxZuXKljsW1a9coKirC4/Eodzw7O4vX62X79u0EAgHl+eLxOMlkUrng6upqmpub9W8iHrfb7dhsNjVI4gLbbDZcLtcSvkqyFjo7OwmFQsTjcTZv3kwgEMDj8RAMBjUPNdtt9Pl8mpcdCAT4yle+wpNPPkllZaXq+iYnJzXty+/3093dza5du3j11VdVpSBBI5ljQ0NDS9LNJHVN1lM8Hsdut+s8rq6upq+vj1deeYX6+nrlDGVMz549q/PvwIEDrF+/nt27d6swXgxcdsu+v2hYE4mEjm92CqPdbmdycvL35DvZ7WOB+P7mb/7me+vWreMf//Ef6e7uJhaLUVJSwvr167n99tt59913MZvNOJ1OjRoNDw8rmhE3BxYjnvLCL7/8MsePH1fUUFpaitls1jQnidRNT08zMTGB2Wymt7dXF2tlZSVf/epXOXfuHJcvX2Z2dlZd0YGBAWBRPd/Z2ak81B133KFoTZCcVNmorKykp6cHq9VKXl4e+fn5xGIxli1bRmFhIX19fczOzhKLxWhsbCSdTtPe3q6usbiPy5YtY9WqVczMzBAKhfQdxP0oLi5Wl8jpdJKTk4PL5WLTpk1cuXJFXXC328358+epqqoikUgwOjpKUVERn//85+np6cFms3HbbbeRyWSYm5vDZrNRVVWlaW2NjY08//zzGtjZsmULr732Gn/3d3/HCy+8wF/91V+xc+dOfvOb35DJZKiqqsJutzM9Pa0CZ4lGSwUXQQmrVq0ik8noopJJn0gkFNmKXiwvL49t27bxt3/7t8qzeb1ecnJymJycJJlMctttt7Ft2za6urro7+9Xd3r37t0amZZKIfn5+Yp6Kyoq1DUvLi5W4zQwMMD09DSDg4PE43FKSkpoampi/fr1ilAzmQx9fX0UFBRoAr7ZbNZoaFlZmUaApSBBRUUFs7OzTE5OalWVnJwc3n33XTKZjAZohFsUwy1C8Z6eHu666y4efPBB9u/fr5uv2WxWRFdcXMz69etZu3Ytly9f5oMPPmBgYEBzjIeHh7XKic1m041h2bJlzMzMaO5yTk6OJgqMj48zNzfH2rVrWbNmDc3NzVqMYXh4WLMwJHf3C1/4As888wxWq5Wf/exnVFVVYbPZlEedm5tTD0LWtSDN+fl5pqenSaVS5Ofnq6xHULQELGOxGF//+tc/EvF9LErPi7bJYrFQU1NDbW0tsBjNgcUIrcViobq6WnfuVCrF3r17NZNBmtlsZm5ujgMHDhAIBBgfH9ekeElgl6IHsBQByk4nu96uXbs4efIkhw4d4uzZs6rvSyaTlJaW4vF48Pv9Gj31eDw4HI4lObyiAxNtkkRQbTabpuCtXr1ao3GSF9nW1qaaJ3lfWeTZqEGul432nE4nd999N62trTQ3NwNQXl6u1TvsdrvqvD772c+qQj8ej6s2S2QO4q7BoismGS1f//rXOXv2LPv27cPv97NlyxaOHDmiUhFYrHhy+vRp9u3bh2EYqkWTZ5YgA9xIV7JYLBQVFWnFnLKyMkU12al74qZGo1F11TZv3kxTUxPNzc10dnbyzjvvaLRYslEaGhrw+XxUV1dTXV2tQY/R0VFmZ2cVOcg8kPGz2Wx0dnYSCAS0YEBfX5++y/bt22lsbNTxykYsIj4WxCPzS4oiiEjdMAzVz2VHVGtra1UTePr0aa1W5HA4aGxspKioiNWrVzM0NMTY2BgbNmzgzJkzqorw+XyKpgzDoLOzU58zEonQ0dGhyFneRxCiFAmRLBPJJf9wOpjFYsHn8+FyuTRFVKoWwWL2x+zsLPF4nB//+Mds2bKFcDjMwYMH1YsJhULMzs4qDyvBIdlsBOVnqxjkZ5lf8tlvfvObKo7/qPaxcHXn5+dVHiBRN6fTqZFBn8+3RDQrIuFgMMj27dt5+eWXNe0MFglT0S/J56VJmpZkaMTjcS1/Iyr/b3zjG0vErqFQSGUytbW1nDp1ipUrV6omCdBSVqFQSHdxaalUiry8PBKJxBKjJa51dp6xwPZIJILf71e3Tgzb+Pg4K1euXJLZIO6huGXiQkWjUU07e/PNN6mtrV2yAN1ut0akYTEvdXx8XJ8HFheaCGvl9/v27eOrX/0qBw4coLq6mkOHDvHzn/9c3dVsycorr7yCy+Wit7eXrVu3LjHU8uzZLVsQLQYOFo1FMpnkjTfe4Ktf/aqmJkajUVpbWzWANTY2tqTmokh+otEozz33HHfffbeWsBIeStxfuY/8W6QkkjIWCoU4f/68PnO2yy9cG6DSGnF35Xew6HpL9Nrj8ehmMDs7q7nq8XicBx54QOdGtpBZmtzP7XbT3NysEfKDBw9y7NgxrFarrh2r1cqpU6eorq5WEX5JSQkXLlwgEomoa51MJvF4PGzcuJHOzk6tRCM0x4cLgMi1ACorKzl79qwmDmQjUVg0/j/72c8oKSnh+eefVwnbQw89pEa0qKhI56yoAbL7Wf4GKLgoKyvTlDiRx+zZs0e5wH+qfSwMX05ODul0mtLSUiYnJzWzILsqSVNTE2VlZVitVoaGhrDZbEsqVWTXEtuwYQPnzp1T7VAymVSiOhgMkkqlqKys1Inq8Xjw+Xxag27FihVcuXKFQCCgRtNms3H+/HkAtmzZopokWESswWCQtrY2wuEwfr9fJ5Pwa1LpQwzoh5O8y8vLlwywVFKR4gKAGmbhUrKTusVIyMTo6OjQrJeWlhZFCXL92tpaXRidnZ1KiI+PjxONRhkbG6Ourk7V/IBuJI899hhvvfUW3/jGN7DZbFoZRTRZwsmK0X7uuedIJBIcP36cHTt2qN5L3leMT/bEjkajmuzf3d1NdXU1zzzzDHAjiV4WlcVi0aR6QbXChcHiZie5wILWnnjiCTWaY2Nj1NfXE4/HlauV+6dSKTVQEk3Pzk/2er3E43H9nSAq0TiKwYbFhX3PPfcoehHDIghPhO8+n095OtGxSlEDWKxM0tzcrAUO5F337NkDoM8i2rxIJKKyJb/fT1NTEydPngQWDbLX66Wrq4uxsTG2b99Od3e3ZiFlb3iioxQjPDo6ql4ALG7+1dXViiZlTAOBgNY13L9/Py+88AJFRUVUVlZy+vRpRWlCB2TrXmWtyJhK38lcz9YjlpWVceeddyp3+Yfax8LwwQ0XTRARoEawqamJ7u5u5XlEyxYOh9XYHT58GL/fr4GI9evXa4UKEWxKxFNEsY2NjSqkPHHiBA8//DArVqxgYmKCl156CafTSX19vSKGsbEx3nrrLVavXk1dXd0SklYGYnR0lFQqhd/v1yoWAsFF0CzfSaVSdHd3Mzg4SHl5ORaLhbGxMa3l1trausQ4ZwthZVFKk+IHMinFJens7GTLli3cf//9nDp1akn6nqAQyQsWd8Hr9ZJKpejr69NKIqlUikcffZS//uu/5he/+AV/+qd/yubNm/nVr361BPlIkYJshJJMJjl06BCRSITXX3+dv/zLv9SUNGmS7ibXcblcys/df//97Nq1iyeffFJdRHHtxF0OhULceeed2O12mpqaNDVQdHgdHR26mQKKEMWtTaVS1NXVEY1GlXbJFmbLXJRAlcvlWoJs5d2l4o3QITI2wp+GQiFaWlq0qIHb7dbKL+J2iosoAYhsGkD4Z9l0DcNgaGhI5UkHDhxQIX525SIJDonGUPq7t7eXRx99lEgkokJjeX8pwpFdWxJuBIzkWWTdSjqhGMr29nYMw+D48eP0/68yV9FolDvvvBO4kYYJi8hc0g5nZ2e1+Icg9mwRucwRWcfy/UQiQWVlpVIQMzMz/6S9+VgEN370ox9975Of/CQVFRX4fD6F7ZLsHo1GmZ6eZu3atczMzOBwOOjp6eHBBx/kzJkzfPDBBxqhbGtr07xQqYrS3t5OLBajuLgYt9vNhQsXGBkZoa+vj4mJCdWKfeYzn+HKlSu89tprqr0qKCigsrKSVatW4Xa7ueeee+ju7qa4uJjvfve7ALz55pskk0ktHX79+nU+97nPUVBQwMjIiAqqJWncbDYzMTHB/Pw8JSUl2O12Lco5NTVFaWkpy5YtIxqNYjKZtCBBc3MzX/va17BarZw4cULdddFy5ebm6q4pos6pqSlycnJobm7m17/+NV/+8peXcIhdXV1Eo1EuX77MwMAA169fB9CS/7C4cOvr6/F4PLz22ms8//zz3H333Rq0MAxDaQops57tauTm5mqRg7fffpsf/vCHAFoIQVyd3NxcXC4XJpOJZDLJ5s2b+eEPf8h7773H7Owsn/vc53jhhRd4//33sdvt5OXlqTslkhKn00lJSQmXL19WLeTg4KAGVWSRulwu+vv7icViTExMMDIywrZt2+jt7SUajZLJZKirqwNQQbPoE2FRL+bxeFQ4LpVaPvjgAw2+WCwWLdrgdrtZs2aNGqORkRHOnTtHX1+fBqJEClJRUUFTU5NG8d1uNyUlJfz2t79lYWEBj8fD2rVree+990gmk5hMJh555BG+/e1vK3KTQIgI+a3WxWME7HY7p06dorKykuHhYZVViaZwaGiIsrIyNV6jo6Ma3JK5KkcBjIyMqN41FouxZs0aqqurefvtt3nvvfd4/fXX+dKXvsT+/fsJh8NcvHiReDyuxR0ymYwGfEpLS7nlllu0XL5Uv8lkMkxMTGC1WjXgIno+gOHhYQoLCykvL2dmZoZr164Ri8WYmZmhs7PznxQwfywQnxQaqKmpoa+vj0QiQWNjo7oqgiLOnTtHMBhUw3bmzBkV9wpy6+zsZO/evTzyyCOsX7+eBx98kHQ6rXXmxNWU8kidnZ20tLSwa9cujh07xokTJ5bwTHBDDGy1WpUIv3TpkhYvlV1JILlU2QVUkya7pnwuu9SQlOLOlsGIhEDKFYkMRNLsxEWEG0S6cE8ijenr66Ouro6hoSGqqqrUZZV+DYfDDA0NUVlZSTqdVjSYXfMN4Nlnn+XcuXN6LMD27ds5fPiwunuGsZgyKIn1cAMdyHMJd3v+/Hm+9KUvcfz4cerq6vjSl76k6Equ9/DDD1NXV6eURXNzMydOnODpp59WVCppeYAWDkgmk0rGr169WsdAauAJ9xQMBrHb7USjUUVxdrtdg1viMgNLEPrq1as10JId+BAvZdu2bUvoB2lWq1XLitntdjo7O7VfpM5ddtBM7if3amtr4+GHH1ZXc8eOHXrdsbExDh48yO7du1m9erW+Q11dHS+99BKNjY0qsZJAgYyzyFIEQdXV1Wll7Y6ODk29lM1CkJe4nSJdOX/+vI5La2srqVSK48ePc+zYMdra2kgmk0vkO5IFJXNCpC6yRqUG4tDQkPbjhyVb2c8jVbarq6t17mYbyo9qHwvDB+hilmBC9lkEkkxuGIYGMbKrRkjUVLgqWFysbW1tPPbYY1rZ4dVXXyWdTmt1Cat1sTTVfffdx7Vr1+jo6NCJJ7oruDEJJdI1Pj5OUVERhw8fxuv1arlxWORfgsHgkjp9skikkoXIaQCt4Sb3qa6uXlKZo7S0VCu8hEIh2tralkS6pMnkFV5U8nANY7FU/+TkpG4sMhEDgQChUGhJNd2ysjLGxsZ0gj/yyCM8//zzvPLKK3g8Hvbu3cvTTz+tC1UMe3YpekCNmUTnXC7XEo5269at/Of//J954403+NM//VN1tYeGhpiYmKCkpIQdO3bQ0tLCm2++qVxWUVGRFh7du3cvbW1tvPTSS0vGyWazUV9fr4GC8fFxLQohYyRGCBYXmFTQFn4PWFLtp7Kycgn3ZLfb9W9ww0BKsn48Hle+MRqN6hEF4h7abDY1PKtXr9bNRLRzUotPNIN79+6lurqanTt3YrVaOX36NIODgxw6dIgnn3xS3czS0lJsNhuHDx8mGo1q7rW8++TkpHpVgUBgyfkutbW11NbWcvDgQY3AwmL+u8hlAA26WCwWzYuV97z//vtVSiObdnZAAlgCQLKDa7KRiEZPgl/ZlALcAA/SsjcjcZ2dTucfDG58LFzd/fv3f+8zn/mMkuPiJkk+oN/vZ+vWrarXu3Dhguq5hAOpqKigvr6ea9euUVFRwZo1a+ju7ubq1at88pOfBKCmpob333+f5cuXMzc3R3NzM9u2bePkyZOcOHFCpTD19fVUVVWxYcMG7fTBwUFOnz7N3Nyckv7r1q2jtbVVXWXRGFZUVGhK0tTUFMPDw1rdRXIObTYb+fn5VFRUMD4+zszMzJLqMKLbWrFiBV6vl7m5OZXcjI+Pc/HixSWVUGZmZnTRlJSUkJubq5oo2TzWrVtHW1sbdXV1rF+/Hq/Xy7vvvks4HCYnJ0crpthsNnp6emhubiYajfLzn/9ci7K+8sor+hzDw8PMzMyoa2c2mzUbJJlMqn4S0PSmL3/5y7z99tvMzc1x6NAhfD4fzzzzDM899xx79uzh3nvv5Ze//KWip4KCArq7uyktLaWxsZHVq1dz5coVjh49yq9//Wv+/M//nLfeeks1XnIa3IoVK1izZg3pdFo1gU1NTdx1112aYREIBLj99ttVJ2m1Wunr69OMDKvVqlkyPp9PdXwzMzPMz8+rbkz0k3/2Z3/Gf/tv/02vL5V3YrEYt912Gz6fD7PZzAcffMBdd92F2+3W4ruXL1/m4sWLdHZ24vF4WLVqFcuXL6eyspKHHnoIn8/HhQsXuHz5Mr29vfT09ODz+Vi2bBmvv/46eXl5Wt9O3s3lcjE/P097ezv9/f184hOfULmVHNR011138bvf/Y5MJqOut3xG3isWi2lqp8/nW5JDLl5JJpPh2LFj1NbW8sUvflH1i1L5RnSEki/s9XqZmZkhnU5rrUBRSFy8eBG4IXGS51ixYoVeCxar38BiBlF2ZR3JjBocHOSb3/zmxzdlbd++fd+ThS15sVbrjVI1VVVVrFy5ksnJSa5evapC3t/85jeqvh8ZGeHWW2+lpqZG/7PZbFqO+rOf/SyA5vt6vV42btyoaTNiYKuqqrRIpRiCQCDAW2+9pUR/VVUVX/jCF3j//feJRqMqmrbZbPT392tRgIGBAR2kRCLB1NSUIsmhoSFycnK0HNTs7Cxut5vh4WFN2env72d6epqSkhJdcA6Hg0wmo4noskkUFxcvIeOTySRr167lwoULlJWVkclk2LNnDz/96U8BtGhkIpGguLhY03ympqYIBAK8++679PT00NHRgdls5gc/+AGvvPIKjY2NXL16la6uriWuthz9ODIyojmUIkZevnw5169fp6SkhC1btuD3+/ntb39LQUEBp0+fJpVK8dprr7F69Wr+63/9r/zN3/wNsJi7+8wzz9De3o7L5cLtdvPYY48xOTnJtWvXOH78OGvXriUQCBCLxTTPt6CggOnpadasWcMdd9zBAw88wLp167Qo6gMPPIDJZKK3txfDWExfCwaDegZKIpGgv79fRe2f/vSnSSQSDA8Pq6TDbrfrPJRn/Rf/4l/wi1/8QnNuJVc3lUoxPT2Nz+fTMmvT09M4HA6mpqYYGBhQLlk2vf7+fnp6ejTFcHh4mHQ6zbvvvktnZyclJSX86Ec/4stf/rIWcMjJydFKysXFxZhMJgKBAGNjY5SWlqoo2+PxaI5yf38/6XSa2dlZDRb09vZq5oPNZlOjL0UTuru7FRXPz88Ti8W0evmTTz5JOBzG5XLpxixFFkpKSjCZTMpNyyY5PT3NLbfcwtzcHK+//rpuQpIHnC0Dyy5nJqXhrFarFqzIFud3dXV9vDk+Sdbv7e1VVBcIBPD5fDz++OOYzWb6+/s5ceKEpoV5vV4ef/xxTp06RV1d3ZI0GliE9OJihcNh/vIv/5L777+fDRs2cN999wFouSLhCKQkuxS0lLJXwJJDZ6Qo5SuvvEIqldKqwYZhcM899+jpWFImXKKJAs+zI1lSQNHlcv1eqR1ZCOKSeDwejcRJVE6eT1xJ0QJK1E80hcFgkP7+fpqamvRwm+zjDMUVHxsbY+PGjfT19RGNRvnEJz7BAw88wBNPPKEcoyx+ccmtVitXr17VdxL5hYi7hacRd114WuEay8vLeeSRR3j22Wd54YUX1IW2Wq28/vrrtLS06Cl1L7/8siIHKXMuIm05IU3uJ5KeV199lUQioaXjpT6fvMfKlSs1NS5bmJtMJtmyZQuVlZWqtROeTcaurKyMvLw8dfUlsi7ul2xCkvYnZ5vAYnCnurqacDis/GtpaemS9MpswbdIYDweD88++yx79+5VVzUejzM0NKSnyO3Zs4dIJLLkiEU5rEkOYQqFQkqjfFQTYyhls2RTaGpqorW1lb6+Pnbu3MkzzzzD7t27dR6J/Ce7CY0g7y1pmPKeQ0NDeoaMXMNms+n52nLUgygMBA0KfSKawtHRUXXrP/Ycn8Vi4c4779TdRSz8Y489BiwWDBUdk8ViUW0TLE52+ZykuExMTCwpqZ1KpVi9ejWHDx8mGAxqHu+ePXt4+umnsVgsSnyLgRPSP1uL5HA4KCoqUrGznG0gvJlhGKrel0Utp0ZJkzxCm23xeEfJtRXeQs7ekA1gcHBQc1wF9WZXxoUbguXsfF673a7HRIp27dSpU1ppIxqNUldXh9/v5/Tp03qtxx9/XBFWMpmkvr6ev/7rv1YNW3bwIvv+2fyX8F5ifIXnERJfeM8f/OAHuN1uvv/97/POO+/wyCOPcOnSJZqbm/WZ33rrLTZv3qzXFNlFd3e3GlmRfRw8eFBP4xJ3DxYXUkNDAx6PRyVCooUUXkjkGGL85Z1KS0uxWCxaS0/c+N7eXg3gSP1IWJQGycKTfhLiPxAI0NfXxz333ENHRweGceNQJiH0ZdyzC6YK3ypk/rPPPsurr76qqEs2S9FzBgIBnnvuOa0pma3FlEOfYFEPKRo+QUrd3d1qkIqKiojH45SWllJZWakyHqkX+cILL+BwODTPtqysTE+Xy+bI77nnHgUshw4d0jkiYyqCfEHEYsTC4TArV67E4/FoDUDR+opxlL4RgbWsBVh6DOaH28fC8OXm5qrgV4SjEkGUQoter1fzDrPLfbe0tHDy5EkdWNFHyYBPTk7S0NBANBqloaEBq9XK/v37eeKJJygpKeEv/uIvOHjwoAo1hbSVXU6ie9ml3ru7uzX619jYqFE6OQBdtIaSMuRwOPSw8LGxMSXSpbCo1bp4HqssvOyCAULASylzMQhwI8KV/XkROcupcLKABaX+p//0nzhy5Ige6CP9Ojg4iN/vp7e3V4XB3/rWtzhy5IgS2yJKhhui0mzBMtwIsmRr+6SJ0XC5XHpQ1L/7d/9OkcCJEydobm7mjTfe4KGHHtIIrdW6WBZ/x44dmhp4/PhxrFYrNTU1WurJ4/HohiDHWsqh84JwT58+zdjY2JKiBR/OEJD+9Xg8eoKeRNUBjSoDei25hvShPKdsmGLkZI4ahkFdXR1ut5vW1lbdoLNPkBNuVg4QAjS4J0bIbrczPj5OWVkZfr9fNWxDQ0OKjgA1sGJYuru7NYAiAKGmpobt27crWhUDJwULOjo6NOBz4MABDh06xOnTp/X72X2XHXwQiUpHR4eiWXnHhx56SOVVsFiYIR6P09LSoodDSUms7EKyEkCSNDq4ceyCbLLz8/MfYW0W28fC8MmxjxLeFqP35JNPArB161asViudnZ34fD49SEUGTfJ1PR6PRozC4bDmfErO6q5du3j55ZcJBAKa5rZixQq++93vappPXV0dPp9Pj60D1ChHIhEOHz6sgmY55wDQXV3kKXImqkSd4Yahynb9sk8Mk78JopWodnb0VpLiP9zGxsZUPCsoJnshiwslUpq+vj4tn2632xVNulwuDh8+zOOPP667s0R64UaEb2hoCL/fr0Yfbky87EolEsUUoyeb2i9+8Qs1PpIRI5tBQ0MDly5dYvfu3Zw/f57HHnuMAwcOaIHS8fFxHA4HjzzyCIlEghMnTgAsqVCdXWhUDHx7ezstLS10dHToXHK73VgsFhWXS6VjqY8o2RwfdaSmbFrSxydPntQoP6AueXZWinx248aN2O12PZrxwzm+kk0k/87eRJ5//nk6Ojo4ePAgW7du1f7PFmgbhqHuoVTZcTgcuN1uuru7dTwlb1vqAZaVlVFTU0NjY6OW6JJ8ZvlOW1uburZCJWUj0+yNOB6P67kg2efcZvPRhw4d0rNk5BqC3KUJZSDjL7QB3DhxUFJZJcf7D1VnMf2h8sz/r9ott9yy8K/+1b9i69atrF+/nmvXrnH48GEMw+Dhhx8GFiecpNIEg0E6OztVXZ5IJDRlyel0KjIStfqOHTtYt24d+/fv4pkUmwAAIABJREFUp729HZ/Ppy7nX/zFX2j2hzQptS4clgy6VHSRhSG7cSKR4OjRoxjGYgGAHTt26ASQ9KXa2lpNlJf3Ea5Cqg5LEYZQKKSHumSjFpkQ2SXxxahk832CRrOb1bqY/7hnzx4SiQRHjhxh586dhMNhWltbMQyD3bt388Mf/pC9e/fS2dlJZ2en8ozyrFu3bl1yNKLIGD6M8D6M9gBefPFFuru7qampobOzU9FJZ2enloKShd/Y2MjXv/51zaARVAg3Mk3a2tpobm5WFCnJ7iInyt5gmpqa8Pv9NDY2cvz4cU0Ts1qt+l3hPgXhVldXK18qBkUWp7yjpBTW1dXpXNq9e7ceIC8l6AXhGYahm6GUOMtO2ZJxEoQmz+j3+3nqqafYu3evuo4//OEP9Xti6KTV1dVRVlamLmdHR8eSbKLa2lpNFLh06ZJuiFLQQVCpeCqGYfDkk09y3333LTG2sJT2EAMuGTaCBjs6OvB4PNrvUlXpw32brf8UzlrAgfDkMt8kwyn73bO9jf9VFNfER7SPRVT3v/yX//K9V199FY/Hw7FjxxgYGODBBx/kU5/6FDk5OVoBuKuri1WrVrF161bm5+eJRqNUVFRoqlowGOSuu+7C6/XS19dHLBZj3bp1esDye++9x/Lly7nrrrv41//6X3Pvvffygx/8AJPJtCQ48uKLLypxfuLECT1nNBgM0tjYyMTEBI2NjRolq6qq4je/+Q3Lli1jdnaWPXv28NJLL6kmcG5uTnVoExMTVFZWaomrZDJJRUUFBQUFrFu3josXL+L1elmzZo0e1SfFFqXMkVQFBvTYymQyyVNPPUV3d7dmIsRiMaampjAMQ6NpoVCIbdu2qWuxZcsWzp07x/T0ND09Paxfv15zhWdnZ8nPz9djK3Nzc3E4HJjNZuU0JQInf5c0IUF4MhHfe+89/u2//bfA4vGWDz74INevXycajdLf36/RafnuyMgIf//3f89Pf/pTjWSbTCbuuusuSkpKSCQSzM3N8cEHHyyp3lJSUsLc3ByRSESjpyIf2rt3L++99572qZxXEovFGBwcVIpCDvSRlKr+/n6VFo2MjCh1MTc3R25urhYpnZqaoqmpicOHDxOLxbjlllv0oKKamhruvfderR49MDBAVVUVvb29Wk1Yyj719/djs9lYtmwZJSUl3HbbbfzgBz/gzJkzHD16lNHRUX7zm9+oUZRsEEDRTnFxMYZhaEaOHAyVyWTo7Ozkgw8+YGFhgUgkQl9fHyaTiStXrpCbm0tFRQWf/vSn2bNnD/fccw8Oh4ODBw9SU1PD1q1bSaVSmskhhlrK4WcyGfLz87VidCqVorS0FJ/Pp2NhtVo1a0n0u9l8sfSHYRiaFSJBGTl0SQ4Pk1L+paWlGgWWwq+hUOjjfbykiHnn5uZobGwEFguISiGA7OMkg8GgHhspPr/H42HFihWaYnT27FlFCLt27aK/v59QKPR76E7OZBB0Iy72448/TmtrK62trdTW1tLc3EwgENDj7iorK5U3lFQjOXpRjposKyvTMkgSmY3H40sqfoyPj2vyvCSap1Ip2v8nc28fFOWdpo1erUAj0LTyKXS3EprI0CQIVBSoGNBxgA1Cdhxgx2h2XNxKKs4eJ1rHRHeCzqwxVZmMu+p4Vt3JRNcpJc4rvOQIcVeIE0ASaE2g/QJRuoPQoHwHaJDm8/zRuW6eNmb2fc+eU+VTZcUgNE8//fvdv/u+7uu6brMZExMTiImJkexCafGjLH2VqoesrCzBXJQZl1ardTPdZNZCHSflYQSlWVoR5DYYDJKdsHzz9/dHT0+PBF12YXkak8hNAwE6szBDPnDgAIC5zrByVCD9/jQaDX7yk5+gsrIS3t7eOHPmDIqKiqQM3L17twjeLRaLTMvLycmRhpQyOzObzfI5KM1DiSPqdDosX75cOp70DOQz9PT0RG5urgzGYmbB6/Lly/K9NptN8CyWsySMs8Pp5+cn5ghOp1OwKuVrpqWliTRz1apVCAwMlNKSmT0tvNgJZVXBS6fTyfhUrl8OvbdarQJRbNmyBVVVVThz5oy8t/r6eoF9rl69iv3790vX3mq1yh5lJ3dyclIaNKzAuI4zMjJQUVEhMBVFBMq1SnyO647ZskajERoYL2Ktj34WSujo+64nIvABLncVi8UiJWpaWpoQhOkgQaOCzs5OxMXFwWw2y/Cb1NRUJCQkoL6+HjabDSaTCTt37kRXV5cM/W5pacEHH3wgQZGbjTKwI0eOYNOmTcI343zVuro6Wbw6nQ5paWmCz1RUVEg7nTpZpU8b3VG4KVkicqMBc756NEIwGo2oqqqSJgsHaPf29gp2x4vAutJzkO9N2XRgp5dlOcueo0ePoqCgQMTx7M5SnsUuH3GywMBAcZmhhT8vLlAG+l27dmHdunXIz8+XJoBWq4XFYkFqaiqMRiMqKircaDEU5yvxsHXr1onbDqk9arUahw4dwsaNG/HJJ59g48aN8p55H3zd3NxcmEwmWCwW6Z7ytUNCQrB69Wqkp6fD398fK1asQFtbG06fPi3Bj89V+dzpyKIM2Eq5mVK4z8+aGabNZpOgTBqSTqeTUnPlypUAIPNaAJfjUFpamtuhxvIuJCQEBQUFqK6uRnBwsFs3mIcQnxvXCZ+3p6cnRkZGEBkZKfN3DQaDGx534MABlJWVCc+PzseJiYkwmUwwmUyyR9RqlwyTuBsw55PY3NwMg8EgVLX29nZpirCTzksJ4XA9E9Mjbss/Stmh8vCgbvxx1xMR+Pr7+2E2mxEcHIysrCy0tbUhICAAXV1dgvFxUHNZWRlqamoEi+GD+d3vfgcvLy8kJydjy5YtWLVqlbz+qVOnUF5ejqCgILECAiCmkgxcVqsV77//PuLj47FhwwYZyRcbG4uoqCg56fz9/TEwMICmpibcunUL+fn50Ov1KCkpEQmPw+GQjUxDgPLycuksDw0NISEhQQDbyclJacZwYxPLam5udjPffPQiLeOll15CUFCQYJwU8BMDYlBsb29HUlISmpqaUFRUhFOnTkGr1UoAtNlsYs0OQHhfzEKVnUDeU0JCgowJCAoKwtmzZwX/U/ohGo1GkRDW1tZieHgYISEhUjrz82QWyfe7bt06oSNlZGS4NbG6u7tx/vx5REVFCZcvMjJSPA8ZMAB3RxB/f3+57/feew9tbW0AIHwyOrUosxGj0YiMjAzhyzErJM+P36d0DWHW++i/0Y2mtbVV6FPMsknx4JB3NnIYEJjtMXhVV1dL4FQGxtWrV0twZtNl5cqV4tzD9VpZWSmVwfDwMGJiYlBUVIStW7eir68PISEhYpXF93vt2jXBnvmMNBqNBChadrGbfvr0aSxZssRN/6uccazEvJVGBFwTj8ONWbkAruzY399fcPAnvqvLwS/Dw8NuJopqtVrcdbl5OEuisrJSPONoXZWRkSFKCYfDgebmZglyRqNRZjRQyE3gmVdMTAx6e3tRUVGB4OBgrF27VmZ6sGNH2REdN/Lz8yVoKuc58APS6/WYmJjA5s2bUV1d7eZppvSUI9DLQJCYmOjWsGEg42kHzDUsABfxdc2aNUhNTUVZWRnUarVoScmf48Lp7OxEcHAw9uzZg927d6OxsREvvPCCPOfQ0FDBPGnjzVOVNlpccLwXakrfeustmEwmvPbaa3KoKEHr7u5utLS0IDo6GlVVVUhOTobBYBDHFgZtpdknTSbef/99HDt2DIAraNJPj5zN3Nxct2wgNDRUZlUoHbBJyzEajXA6nUKOjoiIECMMpW8igwg75yzHCGsoPydgTgvMwM/nzmCldKnmxc/J6XSKrnffvn2ora3F4cOH3ebQslOr1WqFr0l6kRLkT0lJkY4sAyopOqRq8Z74Hsxms3jnMVOn92Nra6vbmqMWmP/Oz5ivr9PpkJqaivr6ercgxkYF4MKY6+rq3PYh9dbj4+NunocjIyPQ6/Xo6elxM93lGmNTkJniE29EqrQ0T0tLQ3V1NdRql5B73bp1CAkJkeyHp5xGo0FGRobI2h69/Pz8sGLFCrS0tEjwYWAiPhEcHIz4+Hh4eXkhNjZWLMvVarWUDcQ31q5di7ZvZzUAc/5fvBioHzVhVJaPCQkJKC4uFqE5sxaWutyIra2tMtuUnWQuauXp53Q6JRM0mUyIjIwU8jddMB71uWOpc/jwYTEXYIl28uRJdHR0wOFwoKqqClFRUULu5UYD5ki27FgT3P7oo4/gdDpx+PBhGI1G2eDkEarVLi1sfX09GhsbERsbC6fTKQqLkZERKZ2V3DhumpycHJw6dQqbN2+WWSc1NTXy+teuXUNSUpKUs/xciFWxfFMqevisGIxPnDgBAG4bMTAwULAlmn8yAyNmy/fH58Js89FsRVmi8X2RGA+4cC2dTod9+/bJ56QU8gNww7mUpq6AK/unXyNVH2lpaeKMw8xq27Zt6OrqwokTJ+Dt7Y3s7GxUVlbi4MGDcDgc+Oijj2TMwVtvvYVt27ZJ4FUaqwJzZru8D9K96O3Ii56TJpMJ3d3dsNlsQijnAcOsllimctg6CdXKS3mg0+KfEMbdu3fxfdcTEfgWL16MwsJCOBwOCViPXo9+Tcmz48WfVw4pYanwuO/n1dLSInMI9Hq9ZDLnz5+XLijgygj4O/z8/MTggBlHXl4eKisrxW2F2cH+/fvxwQcfSBnx6MJn+k+WvNJ0tKenRxoTgAsLJaWGpSA3HzGq3t5efPbZZ/J+uBCBuWaCp6enkEwZyPhaHO5DbhUAAa+tVisSExOlEcON/cknnyAoKAj79+93o5IA7kEsJSVFaBSAixeYnJyMysrK72wop9MpnDnO1uju7pbgl5GRgcOHDwum19raCqPRKAcoMeHm5mbU1NRI6c/NQkkU3x9pJAz2DF7clFRv0L3abrejvb1dynIlf/Hy5ctYsmSJYNKkZTBw8LkVFBSgoqICwByu1dnZidraWnHBsdvtMBqN0Ol0wmGjdhmAyMrMZrNgb+QAEnPW6XTw9PSUwHHhwgU0NDQgNjZWGi7nz58XfJMVVnx8PFasWCGJCDNEBjpl9cFLSV7mOmfTi640pLYouYfKtUJ5IIM4nxmfEQC3BhU/n56eHjc44/uuJyLwzZs3D6WlpRIYlFgG/z8pKQnh4eGi0qDSor6+Hv7+/khKSkJnZ6dkauzwRkZGivqhpaUF9fX1YsVNzG94eFhOJqPRKFbq/HAPHDggmmE/Pz9xjfHy8kJSUhLKy8thsVig1+sRExODpqYm4VoBrqBLVUhCQgIqKytlngY1nwxExD7om6YcSchMlxudHTpPT094eXkhODgYU1NTyMrKkuyNG02tdqlMyE+8du2aGAb4+fnh2rVrbmoDZmyUBrErymFAXGg6nQ5FRUW4dOkSTp8+jeLi4sduBt5zRUWFW8bC+RN8XyxVlV5t/JqyccMM7Y033sDx48cRFBSEyMhIKaUYJMk5JH5IMJwbit1jZgx+fn7o6Ohwc7cmzme1WrF8+XIEBwejrq4Oq1evhsPhkIxXo9FgYGAAKSkpuHz5sptLMjPviYkJPPXUU9Llpc6buGlPTw+qq6uxY8cO+VmTySRzkZVNIi8vL+h0Oly7dg0dHR2SZTkcDmmC0Y49ODgYiYmJEmgaGhrExGNoaAjHjh1zm8FB6SazZDZfkpOTZW/S4aW7u1vgHaPRCLPZLKUvuZYkTldWVrrp4U0mk1Q8xMXp18eGhnK9K2ECfs+j1lXcF7dv3/7emPNE8PgKCwt/TRPBZcuWoaamBs8//7y4fVitVjQ3N2PBggWIjo5GU1MTSktLxVHEZDJBpVLhxo0bwlanxY3ZbMbt27dx7do13L17F0uXLsWqVavw+eefw2KxYNGiRbh06RLu3LmDiIgIFBcXIy4uDr6+vtLVpanjzMwMlixZggULFogrxcTEBBobGzE2Nobm5mYZ8jw4OIjp6WmsX78e3d3dGBwcxPr16zEzM4OPP/4YJpMJY2NjmJqaEiuqqakp0eI6HA6MjY1J9tfe3o779++7lVQ+Pj5YunQpIiIikJCQgMHBQWg0Gty+fRuff/65yOWIk01PT8vIyfHxcahUKlRXVyM+Ph4RERF4+PAh/vznP8PT01O4hYsWLUJYWJhwpeLi4gR2ePrpp5Gfn4/du3ejpKQEX331lZtFldFolOegVqvlvzk5Ofjxj3+ML7/8EosXL4a/vz/a29vlefr4+Mj98u+ACx/Kz8+Hh4cHTpw4gVOnTuGnP/0pvv76a9y+fRtGo1GcfRYvXoy7d++Kq/XIyIj8fh8fH+F7hYWFISwsDG1tbbh3756URwTXvb29oVKpcP/+fURHR+NHP/qReN+xuUJ3ZjoZZ2Vl4fz587hz5w7GxsbcNi4D/YsvvoioqCiRPE5MTGBgYEBUEe3t7TKmksPKR0dHoVar8fTTT0v29+c//xm9vb3y3lasWCHlL912VCoV/uM//gPj4+OYnp4W7S07tP/8z/+M0tJS+Pr6oqqqChMTE7h37540GD09PbFixQqEhYWJldTY2BhGR0fls+vp6YGHh4fbdLTp6Wk888wzYkM1OjoqbssLFy7EzZs3YbfbxZ2Ie2d6elo+fzqSA65McnZ2FvPnzxdYia42HFoOzPky9vX1Pdk8PoKQLCnJxqdsZdOmTSIBs9vtUKvV0sEMDw8Xfz6j0Sjpb1lZGerq6oSCwiyKqgdiGX5+fti2bRumpqZw8uRJGcjCjibgytji4uLQ0tKCAwcOIDk5GatWrUJAQABKS0ths9mkw9zb2yvSmfHxccTFxaG0tFQA9JycHPzmN79BWVkZcnNzJYvhCavEDblRJiYm3PSlyqxFq3UNszl37hwA11Qz/n667zY3N6O1tVXIpGw69PT0YNeuXfjwww+RkZEBwLXhSQ0iYMzPQYmxHDt2DLW1tThz5gyuXbsmJ7ySxU9unZLyAQC3bt3C+vXrxWFFqcNmYO/t7YW3t7dbWUhVRnV1tVBDDh48KHy+hoYGN6cbZvrMfJQUDT5HUo9o0ElaEQnnzHYnJibg6ekpcr0PP/wQCQkJyM3NxaFDhwC4Sq/GxkasX78enp6eSEpKkkyOnxefTWdnJzZu3CiT2OjMzAOdiQBpL6xQjEajlPE0OiCHj5AJjSn4WTY0NECtdrlAJyUluZkUbNq0SahC9fX10Gq1cDgcyMjIgJeXF3JycgSLJtyibNjw/QFzVCqlUSh5hZQHsrtN7XNPT4/8nLISACD6Y2L0/Gz42SmvR+fPMHB+3/VEBL6QkBDk5+fj+vXrItLnxDMK/9VqtQwSIjYQHh4Oh8Mh2lZ2SdlgIAWDV0pKCs6cOYOTJ0+KUJ9ytoqKCqxbt06G4uj1eimviRmSOHv06FE0NzcjPT0d69evh9lsBuAC0kk9Yfp+6tQpJCcnyyYkxaCsrAy9vb2CS9BdgtgacSUAItV5HJWFGFVUVBRef/114Vp5eHjg7NmzOHnypBufq7GxUco8bqzVq1eLlCw9PR0ZGRmIi4uT952cnCwgeFJSEjZs2IDa2lpERkaKdJB8s9bWVtl4jzYn2OSZmJjA3r17kZGRIfhodna2QAy0hOdFTI4d/YsXL6K/v1+GHa1btw5ff/013nzzTdjtdoEtyAjgzyvxIpav3MzKv/MQozC+tbVV7NF5/waDAd7e3mhtbcXq1atRVVUFAG5BmnABAClp6SyjVrt04RUVFdLBBIBz584hMTFRgj+fAwm8xKCVFCGtVouoqCgAEHcUOh1ZrVaEhobKz5Kz9/LLL8uaPHjwoMApnI0LQLTf7Cjn5eV9h7j8aLBSktt5L8oBV4DrgIiJiRETVh5ufK9KbI8XYRW+FvXd5AvyUFEOeKJR7OOuJyLwzczMiHtGcHAwVq1ahbVr18LhcLgpDUpLS2UTMwgeP34cCQkJQjF46aWXJFASRCeBs7Ky0s0u/Nq1a+js7EReXp6MpFOaClDlwUaJ2WyG3W5HZmYmysvL0dDQgLy8PLz11ls4evSoZAcsk2w2Gy5evCg2WFevXgUA/OIXvxA+4p49e1BdXS3zQZWnJvGLoaEhN+4Z8aoXXngBsbGxAFzB5VHN8YYNG0TznJ2djStXrrg1HZxOFyE4PT0d7e3teP3110VxonzfCQkJ2L59uzSKzp49i9bWVrzzzjvyWq2treKIwsCl1LVygYeEhAiDn7QhZvMMUI/aCfFnifc2Nzdj06ZNQv+ZmJjAT37yE5w/f14MMevr60WPzTEAvOgWwmepzBaUB4zT6ZTAB7g6qOfPn5dKISkpSSbXUSJFXz6lXpr0Ck5XUwZ1q9WKyMhIFBYWYuPGjUhJSZEsidUJv99kMolHoL+/P0pKSgC4eHk0WeC9BwYGSkambAbY7Xa8+eab8ozz8/PdOI7ECWmbBkCyNDIh1GqX9b1y1onSmp7Z/aP28MnJyXA6XS41FotFmn+Pdr4fxev4Pvg7aEbCvUzTCt4vm31/yaTgiQh8fn5+EsgAl3RteHgY9fX1sFqtUuKy48jNzulLPKm1Wq14kHGxWCwW8fZSWjqRx5eYmIjy8nKkp6cjKytLpHLR0dGSWUZHR6O2tlbkc01NTXJiFRcXIyEhAT//+c9x9OhRMRrw8/OT8uLChQvIysqSjRYeHi7uHuzY8QQn2Vitdlku0TlEeRHwNhgMYqrKDf/o5enpiYKCApw+fVrE+Fqt1q3kZfeys7MTzc3NIkHiBgwODhbgvqysTObTKsm9ymHiSooB8RZ2IIeGhrBq1SqUl5eLPRcpNHq9Xp4DKQ78O+DKtE6fPo3Vq1fDarUKiE7MMT8/H+fOncPu3bsFn6X3oFarRVJSkmw4PkeOKTWZTHLvPHwCAwPd6BjKEs9oNOLYsWNyeLzyyis4evQoOjs7ceTIESnvSGvq7OzE9u3bUV5eLhkn1QqFhYWora2VoVOAKzsmO0Cj0QivMjIyUuzOWD1QekbqEAOxkkpEv8uDBw+ipaUFJSUlUtnwoKMEk8FJo9EIfMB74vrgQUxfx+zsbLl3Wn/19PTIfTMZYRCjfJM8QaWrDGEi/j8zPQZ3pekDXYYIB/H6r2RrT0Rz44MPPvj1a6+9Jv9/8+ZNoTf09/cjICAAPj4+0hX7+c9/LmajdGNetWoVDAYDBgcH0dzcLNInWns7nU6EhYVBo9HgmWeegY+PD9LS0lBeXo6HDx+iu7sbgYGBiIqKktkVX3/9tQQ5Dw8P1NTUuA03oi12U1MTUlNT8aMf/QiffvopAODVV19FeXk5BgYGoNfrsXDhQmg0GkxPT6O/vx8FBQX4+c9/LqL53t5ejI2NCWhMUNfDwwMtLS0CznOU5IoVK/C3f/u3ornkYfDolZmZiS+++AIzMzO4d+8elixZgqeeegqBgYGwWq148OAB5s+fD4PBgJs3b0KlUuHZZ5/F559/Lpb8er0eISEhaG9vl1Ltq6++wujoKMbGxvDw4UNpQrATT2AegDDofX19oVa7lAYZGRloaWkRYTnB7zt37mD+/PlQqVTw8vLCkiVLMDIygvnz58PHx0fGFAYEBGB2dlZGPsbExEhG+dprr+H06dNYunQpJiYmsGzZMqH28J6pD+ZI0ICAAIyNjcFqtYojTVhYmKydrq4uKZ/CwsJw8OBB/PGPf5Qxjb6+vmJVz9/71FNP4fLly9JkYEPhyy+/xK1bt3Dt2jV4eXkhNTUVf/M3f4O4uDgZqajX69Hf34+ZmRkEBgYiKysLzz77rOB5hw4dEurX4OCgGDf09fWJZXxDQwMGBwexcOFCaLVavP3226KGevDggXRPp6am8M0330gQAlwH8MTEhJhg/PjHP8Yf/vAHDA4OSoBxOp1IS0tDWFiYZKjBwcF49tlnkZaWBk9PT7E+u3fvHubPny88Ws5iIc2GJTw/z6mpKTFqmDdvHmZmZsSB3GAwwMPDQ2YEBwQEyFhSfp3Y4a5du57c5gbgKgMJoCqZ+7wMBgPS0tKkW8uTnu1wwFWafvDBB26DtXnyjYyMCCcrMTFR6BkEjNVqNQ4ePIiUlBTo9XqxM+cc3ri4OGzZsgWHDx9209omJSWhpqYGGzduxBtvvIF9+/bhyJEjCA8Ph8lkEp0umw+AC6NMT0/Hyy+/LHQEjsxUahKVfD7AnR6iNC149OL98kpNTZVTWq12uf2SXkEiL+BqsFBO5nS67JOoca6oqBCai7J8YtbKRsyjRF1lWceLh5USQ9u2bRssFgv8/f2xfPlyXLt2DX19fWJpTzMEHn6NjY0ICgoSYjrt/nmx7CUHkgoGqhU40Jz66p6eHqSkpMizpfZaSUUh9qVWq8XdmlzBqqoqZGZmoqqqClarFTExMW5UF61Wi5MnT+KNN95AU1OTHJYHDx7Ejh07JODExMSgvLwcQ0OugfGJiYluXnpmsxnFxcXieMxNzgxcSYdKSUlBUFCQYLalpaU4fvy40KK4jon/KrN/mlKw4bNixQoxBuVnbDAYxK+P2PLFixfFNZmzgUnW53NJSkrCuXPnxJyDl/LvvDo7OzE5OQm9Xo/GxkYxxOW6WrlypTSo2ABauXIl+vv70dzc/Nj9ATwhGd97773366effhpjY2MyjUyv12NwcBAmkwkBAQFCzgVcJe7s7Cw+++wz2O12GAwGLFiwAADwxRdfCDDc29uLRYsWSSNh8eLFCA0NhYeHh8zqYIAbHBzEzMwMfHx8cPfuXZSWlsLDwwNZWVlobGyU05/WS3q9Xgac8Pd9/PHHWLBgAX7605/io48+glbrmiXw2Wefoa+vDzdu3MCOHTtw48YNNDc3IyIiQgblJCcnY2pqSgZEL126FBqNRlyZOViIWVRYWJicbrGxsXA4HHJYeHp6yvPgzNPR0VF8+eWXQil4+umnsXDhQvj6+sqfxMREREdHw8vLC7dv35bnXVpaCsCF+dntdvj6+oo11tTUlGRQixcvFua8cigMAMl21WqXSwe74WFhYVAmMAZ7AAAgAElEQVSpVFiwYAH8/V2zk2/evClBbnp62s0D0el0DTbigKXhYdckNg4Sunr1Kurq6qBSqZCZmYlvvvkGqampmJ6ehslkwooVKzAxMSHYMe81PDxccMmpqSn4+voiOzsb9+7dg7+/P9ra2gSqoB2Tt7c3Hjx4gL6+PsyfP18GeI+OjmJgYABarVY+u7CwMHh6emJwcFCgi507d+Lu3bu4fPkyvLy8EBYWhoSEBFgsFhnQM2/ePDx48AD37t0DAPEc9PDwkP3S3d2N0dFRhISE4Ic//CF6e3uxdOlSAK6DiWyJXbt2wdfXFxEREUKW7+rqEh9CDk9atmyZkNBnZmawcOFC/NVf/RXOnTsHrVYLX19fLF26FPPmzZPh4JzKpuRfenh4CIY7MzOD4OBg+Pr6Snbn4eGBlStXynslTjo1NQWtVus2Uc3Hx0doYYTCZmZmMDMzI80bo9Eotl6jo6NobW3F7t27/99lfCqVygDgjwBCAcwC+P3s7OxhlUoVAOBPACIAtAH4m9nZ2UGVq5VyGEAWgDEAfzc7O9vwuNfmpVarxQrd6XTKjIpH7dsBV2ZIGyqdTofKykrxyWMmQcxsZGRETDZXr14NjUaD0NBQWK1WbNmyBU1NTWhsbIRer5dZCcSYSIbu6Ohww5r4vXx93idP7EOHDkGtVmPTpk04dOiQsPKdTqe4hKSnpyM4OBiHDh3Cli1bcPHiRbz++us4fvy4G9BOeyNmV0r9alBQEF5++eXHzhfga7BLrtfrsWnTJnR2dgrFh2RRT09PIfiuW7cO5eXl2LBhA7KysrB3716kpaW5zdNgJ5jZEvEyZnl8HnzPACTr4deMRqOc3h0dHYiKipIskh1hKkyUw8gfzSZ1Oh1u376NkZERwcv4enV1dejt7cWGDRtk2BAzBcIXStdf5dB3ivWNRqNMgWMJT4dizn9hFUFDVQ75Ie7Mi00Ku92OHTt24ODBg1i1ahV2794tWRppWHSg5vOOioqSg5ouReSrEltl2apszhgMBsngd+zYIeuou7sbS5YskaYFsTalzpeQj3I9sjpQqiSIDSsVPsTSeWjzOQEuTNButwumC7g6ycqxBtyDHPegdDtSrm9imd7e3m5rlK46/91hQ1MA/s/Z2dkGlUqlAfCVSqWqBPB3AC7Nzs6+p1KpdgPYDWAXgBcBPP3tnyQAx7797/deJGaSbMsPjvgZA9qlS5fgdDrdBiTTTohfpw8cNwEArF69WvhNBO5phw1ASpnu7m5cu3YNy5cvl7KLyglmB8XFxdiyZYuA4ASGldPpDx06hODgYPH3O3nyJABg9+7dYpTAbmJJSQlycnIAQFwpHA6HlFm0ElKWu1zAbLy0tbW5gfDKIEPHagBip86LahG+l/DwcKGlnD17Fna7XQaJx8bGYnh4WILS46Zo8R4oT+L9MnCRk0haAzc4jV5PnDiBl156yc2KXpnpKRUdyks5ayEqKkqyh5MnTyI7OxtpaWn4u7/7O/E85OQuYrQAJMhxM3P9sfQD5rqF1Hbb7XbpqFZVVcHpdKKyshLp6elCpeH7YPDcs2cPIiMjUVRUhB07dqC7u9utEUElT2ZmpgwUpxrJarWisrLSbX/wOTNJoP1UYWEhAFfTq7i42M1RJzAw0I0OQ303X5eBhtJGZdeXMz5YCiv3KwPR5OQk0tLSxMmZrIqkpCTExMTIuuTBRvciLy8vodjw8ySnEXBJK+kozaFkvPr6+sTs4P8THt/s7Ox9APe//fuISqVqBqAD8NcAVn/7bacAVMEV+P4awB9nXZ729SqVaqFKpQr79nUeezmdTjcbKc7FoIddVlYWHA4HiouLAUDcQmgJxKDU0dGB2NhYqNVqCZZsv+t0Ouzfv1+yLeI4vb29ktVFRUXJSL3w8HDZQMSQiIWUlJSIrTg7grSPz8rKQmxsLHbu3Im///u/l+BXWVmJ4uJiWCwWVFVVia380NAQPvzwQ9TV1cnUM+VIP5awzHa4INgN3LNnz3d0yFarFREREdL5iomJQWFhoWQHDFr0FAwMDJTFGxERgYGBAWzYsAHHjh2DVqtFXl4e6urqxKqKz4sdOt5TT0+Pm7KEAYsBj+9BeZjxwCsrKxNROzewMtNTZo+0mqcNVGRkpOiHKbNbs2YNmpqaUFJSgvT0dJw/fx5btmxBT08PHA4HGhsbERgYKIGNWKpa7RLI9/T04OjRo7LZlNxHytESExNFO8tn0NHRgYSEBLdZJMBc0HjnnXdw7tw5ycadTieioqLkMGe3vaysDAaDQbrOWq0WlZWVQmhmMNXpdMLNbG1txeTkpODJtJRSZoBK70MOWgoODhZNMb+u0+kkgDAYkdjf0dEhuDhHM9Bbj2azFovFjZoFQKzD6C4THBws74kJSWhoKJxOl+6dphu0B2Oy09fX5+YDabVahU6l5PESH37c9b/V3FCpVBEAEgCYAYQqgtkDuEphwBUUlaxG+7dfcwt8KpXqNQCvAS68SnkRpO7v75eTq6amxq3kU3KKGASjoqKgVrvmK9TU1Eg5lZqaiv3798ssV2XJREkaSxlyjdLS0mQT9vb2oqysDMHBwUhLSxOR+saNG2WBK6kIjY2N4sQCuBydm5qacP78eVy5ckWUBVQmkFjKbIHzaCmYV2ZQwJwIPCYmBhUVFQgKCoLZbJZgTtySeNSlS5eQkJCAuro6acCQssDr5MmT2LFjB9555x2cOHFCqD7p6elYu3Ytent7YTAYoNfr0d3dDZPJ5OaCotSi8lKWkTQIoEXX1atX3d4TMwCSe5WqFWXGyM+fF7vaAEQdQAsqul9XVlYiJycHGRkZsNvtMJvNwjNT8jb5bKlVVTrF8PsJ8CszQRKVOe+Y/Dq+rkajEY4Z7aGY4fX19QkIT7cc2kkxe6ODEOkthC+UB4+/vz/6+/tx8eJFXL9+HSdPnpQsjtZRwJwagkGtvb1d1gF5gJwlTAVQU1MTDhw4AK1Wi+7ubuFdAi6+ZFRUlPBWtVotlixZIk0w5Qxph8OBiooKREZGYsmSJeJTyHshR5OORMTpeeAwuCr5gna7XXiWLHcJw/wlI9LvZ/g9cqlUKj8AJQC2z87ODiv/7dvs7n9ratHs7OzvZ2dnn5udnX1Oq9Xi+vXruH79Ompra2Gz2eDl5YXc3FxcvXoVp06dEgmTv7+/lEt8+MPDw7h165bMOqWDRl5eHpKSklBWVob4+Hi30rampgYVFRViZ37y5EnhDAYHByMnJ0eCIVn2JFtu2LAB3t7eOH/+vJgf+vv7Izo6GgMDAxK4AwMDcfToUZw8eRKRkZEygCYyMhJ79+4VUT3gYsmnpqYKXkTlBwMHACEus/PLD7ykpESmw926dUusuux2O86ePQvAFZjXrFkjk8j43Ly9vfH73/9e7MD37NkDo9GIt956Syz+AVdnmJxJDkTiyE69Xo+goCAEBQXJ+9FoNNIx50HDANL2reGn8jNkBsOTn89aWVI/yu5XZpBWqxU1NTWSgfj5+clr6/V6vP/++9iwYQOMRiOys7NlXCMxIofDIRkgN1R6ejoKCgrkPvhvSumZTqfDli1bJJPS6XSipqH3HwDJTmn8SiMLZlP8jGncykBJGabNZpO5sjS3YEBg1/TixYvo6urCoUOHhPTO7u/KlSuRnZ0NPz8/mM1m9Pb2oqqqym1YD0thelL29fWhoaEBPT092LlzJ+Lj4+WQoSqDKg0G14KCAvFA5CFMuVlubi527dolODFnI/OzJtQVGBgo/n/MVvv6+hAaGirB3Gq1yvcRc+TnSZ/C/7YDs0ql8oQr6J2ZnZ39n99+uZslrEqlCgNA9mAnAIPix/Xffu17r3nz5glG19DQgP7+fgQGBgr4y5mvfOis88nIdzqdYs/u7++PiIgI0e+y5ifmQhCbBMr4+HghlLK8Sk9PR0BAACIjI1FZWSlmnHV1dYK3EOehc4zFYhEDBabqlCQdO3ZMSmXAlckeP34cRqMRmzZtEgyQjRm6dQBzk7yUZe7w8LDgHnQg9vb2RmpqqhCaHQ4HkpOThWrS29uLV199FadOnZISfmhoCBcvXhSaw/j4uEzjoouN0WjEjh07sGfPHmRkZOCdd95BXV0dALg5C/MqKChASUnJd2ypeGk0Gpw4cQL79u3D9evXYbPZ0NjYKM2i5cuXo7+/X8pdjtkEXMFbOTazo6NDAHeWkkoy7vLlywHMqV3YVCgtLRUNM8nIzHpoacQRAEosTKkTzczMlMz/0KFDaGpqEoeZxMREjI+P48qVK0LgjoqKEscVZni/+MUv0NHRIXI4Eq3pck1Ld7rG9PT0ID09XYKOshlz8OBBAMBvf/tbt/KVk92amppw5coVCZZUQTCwKK2zWGnQaZpBnlko1yKzYMCVSZKSRQXS+Pg4uru7hY9ZXV2NlJQUnDhxAgMDA6ioqJCDrLe3102Py/dmMplEccX1b7fb4enpiYmJCQQGBsLf318mrvF7Jicn/3vKjW+7tB8CaJ6dnf0XxT+dB7AZwHvf/vf/Vnz9/1CpVGfhamoM/SV8DwAWLFiA4OBgVFdXS7pMNjvLt/7+fkRGRmLbtm0AXDgg7bYpZI6MjITFYhGLK7VaLcAp4CqnkpOThaRKeyva3vPfeXrYbDbRK/JDYElLTJJ+fIDL4j4nJ0coOA6HA2azWYxUiWE0NDSgs7MT7e3t8PPzk81bXV0t5XVjY6NbU0N5KTEelvvsBra1tbm5TjN7UavVaGlpgdFoRGJiIiorK/Hpp59i69atIrPiiU8yqvJkraioQG9vrwTcoaEhCfLKeRnUBvP1lNgkS1273Y6uri6YzWbZ+OPj49Js4f0mJCRIg4rMfGb0LIHZ2bVarWIEwaqA/LL6+nrBIM+ePYvU1FSYzWbExMTIYCOr1SqdbuJ51CHTsZtcUGbeDMxFRUXSYAEgh4cySAMuT8ndu3ejqakJfn5+6OvrE56h1WoVLTQDV0xMjDRkOAe4qalJJFrEElneqtVqydKdTpfDd3Nzs9u4SnLdlBPw2CHn56/T6aSrnZOT41ZO0xcQcBlupKenS7UQHByM06dPw2AwICMjQ3A+BjFvb2+UlZVJp7e1tVXEAsTm+DoktbNhyeqHhiAhISHw9/cXlxzuC6673Nzcv4jx/ZdzdVUq1SoAlwHcAEAT+1/ChfP9DwBLANyDi84y8G2g/L8A/BVcdJaC2dnZL//S74iMjJz967/+a4nqtBffunWrkJQ5db6srAybN28W3IpuzcPDwzJlfmBgANXV1TCbzVJKREVFieNEZWWlLOotW7Z8R+N6/fp1maHBsiUxMRHDw66pZAye/H28SktLcevWLRGtM7hSflddXY20tDTBLUwmk2A6H374IZxOJ7Zv3y6blkRjBg+WA8zWQkJChGDKE3vTpk0i/+NmcDqdiIuLw4ULFyQLbGpqwsmTJ8V/LzIyUiRB7KQlJycjISEB27Ztk5KKpTeJvUpzzUeJ1k6nU0pApRCdQ+EZdJgd0NNt5cqV6OzshM1mg8VikaBCGGJkZATh4eFyIPX19eGpp56S5hBxuKioKIyMjKCpqQnd3d0IDQ3F0NAQMjIyZPre8ePH5XBg2cRDhVljSkoKKisr0dHRIXpbDihPT08Xp22Se7neWHEwO92xY4eUsaGhoZKhc+IcAXyj0ShNMWaJAARXJfa2cuVKFBYWyuc6Pj6O5uZmnDlzRjJuYsnMelmSJiUlobW1VZ45g1NiYiKAOVflwMBAeHt7IyMjA0FBQfjkk09QUFAg+DWrJdKu2PVlsOQ6Z/YKuAJgSEiIm/mvct1cvHhRKjiaELC8JzbIffWokem7774rUE90dDRaWloe61Twv9LVrQXwfTYHax/9wrd43z/8V6+rvEZHR+Xmd+3aBcBF/aAZZ15eHqqrq/Gb3/wGeXl5rl/87axcZiVK1j5HNHKsHbMiDpGhUDwtLc0t6LW0tAgnMCAgQE5bitrVarVMf2MWCbhckTmisaKiQtQnHOTCQTK7du2ShkBoaKic3jS1LC4uloFGDLhKIJ/tfW4uNknY5RwfH0d5eblsTOJgCQkJqK2tlWej3Nx065icnBTtLO3Kab2/a9cuKdmGh4eF+8igrBzczYvlEYO2cnBQR0cH9uzZg8LCQpmnwM2i0WjcsE6+BjBXsgKQrE+j0SA8PBwhISEyvYyWYkptthILIyeOZG0/Pz/JGvj9zFabm5sFTGe2yjVE666enh7ExMS42V7xQLLb7fj0009x6tQpaDQaJCQkyGHMJpjJZBLepNFoRENDA/bu3QvAxblbs2aNZOF8Lxs3bsSGDRtw5MgRdHZ2ori4GBkZGbLWle7E7P5mZ2fjxIkTiIyMxMjICCYnJ2Ut8PkordzS09NhNBplVEBOTg6Ghobw5ptvIjAwEFqtVox7SQcinYyvm56ejmvXrqGyslKC4p49e/DOO+9IwkJTVM4w4bNn8GX3mTi5n5+fzPHg71Ee+FevXkVZWRkGBwfxfdcTIVmbnp4WvI28tKGhIaxZswavvvoq9u7dK4NEyEJva2uThZCTk4P6+nrs2LEDb7zxBqxWK9566y3BjviAKcrOzc1FeHg4BgYGcPXqVVy8eBFRUVHIzs6G0+lEWVmZYA9JSUlIS0tDQECA6IOPHDkCo9EIk8mEiIgIhIeH48iRI1IqnD9/XsqRyMhIGUh07NgxXL58WXAl0me4UZVUD17saCqDG50/OAeXmN34+DjGx8dhsVik0TExMSGLNyEhQeyluGBaW1tFm8qMTqvVwmw2S/Bl04enc0ZGBqqrqwXoB/Ad1xe+H+V/+XVuSgZtZg0sv7h5mQFxIwPuZGhSXfbv34933nlHRjX29fVJhsJDzmKxoKenB3q9Xsw/6YhdU1Pj5oLCAMbfxcOGhyxn4fJ7tVotmpubpfRUq9Vob28Xq6iIiAj88pe/REpKiuCRWq0WDQ0NOH36NF555RXs379f5s709/dLNzUkJAQVFRXw9PREVFQUtFot9uzZg1WrVuHAgQOorKyU5048kuuHJSHft8ViEVI84KIBKbMltVqN7du3S9e3ubkZxcXF0Ov12LdvH/bu3YuRkRF0d3cjPT0d9fX1YjtFmZvT6ZSMmxb8gKsJNDIygry8PJSXl0tmz7/39PSIFpfQh9KwgxAYs382MDo7O2VOytTUFMrKynDu3DlkZmZKB/1x1xMR+DjEmqWjl5eXW7nrdDrFugeYs5AH5qyCQkNDkZubi+LiYuTk5EjHkGx5ZmqAqxQeGBhASUkJvLy8pIw1m81uOl0acVZUVMjmJA2Ei4zaYeqL/fz8EBUVhfz8fKxfvx4Oh0MMTlNTU5GdnY26ujo0NDQgMTERGRkZ6OjoQG9vr3zg5HQpPe0YkIivcFNMTk6K6woxHOoiHQ4H3nvvPRw5cgTbt2/HoUOHsHr1arGAYgBluWowuHpSPT09glMxOFitVtTX18tBwozGZrNJSQs8PgAq/84AsnbtWuzatQu9vb2C49psNjdDU3YNOeiI3n28GBCrq6vdMDaNRiNzXllaExogjltRUSEHBAnNyvkNyk40HUp475xRoVarkZiY6MYpy8zMRFlZmWiCb926hYSEBNnEzOBZclP6qNVqRSkRGBgIm80mOBfL5d7eXuh0Omn6KfFT/ntwcLAbeXp8fByTk5PifceAQycjwkGcrNfY2AiLxQKn04n4+HiEhIRg7969OHDggNhPxcfHizkt1yNNV1nOEgtWznshB7Curg46nQ6XL192I0E3NjYKx4/3rRzUxQqwqakJUVFREg8cDgcsFgvKy8uh0+nEcYmOzI+7ngit7qFDh379r//6r1iwYAEuXbok3bgjR44AcJk4btq0CV5eXqitrcVXX32FRYsWiXV8VlYWXn31VfFnI7hPneXatWuhVqvR3d2Ny5cvIyIiAmVlZWJt7eHhAb1eL3zCGzdu4ObNm+JeolKpYLVaZeOwtOa8CqbUWVlZ+OEPf4jMzEzMmzcPn376Kf785z9jcHAQixcvRkBAAFasWIGUlBRcv34d33zzjSzq1157DdXV1YiNjUVnZyfa2towNjYmNtw+Pj4ICQlBQECAmwbW09MTXV1dGB0dFR3k0NAQWlpasGXLFnz99ddYv349xsfHcffuXdy6dQvz5s2DWu2yZ29ubhbDUQ8PDyxatEhcObZs2YLr16/LPTz//PMICwtDXFycBGtazdOlRdnQ4D3yfrlJfX198Q//8A/4wQ9+AA8PD5jNZmkqxMfHC9TATt+dO3fcMLj58+dL1jd//nzcuXMHL730EkZGRuDh4YHZ2Vl89dVXMrbUaDQKr2xmZgYWiwVWqxWjo6MygJu618WLF2NiYgJTU1NwOp3w8fERzejw8DDmz5+P559/Hvfu3cNzzz2H4eFhLF68GDk5OYKthYWFYXp6Wgi6V65cwc9+9jPs2LEDDx8+hMVigcFgwNdff42JiQlMTk6ioqIC9+7dg1qtxsOHDyWTDw4OxsOHD4VetXPnTvz0pz+Fw+EQa37e++zsrDAaCE08//zz4nZM2sqdO3ewatUqJCcnw8fHB2FhYYLZAq5xrzMzMwJl1NfXY3Z2Fg8fPhTqGA8V6po//vhj9Pf3Y968ebh//z6Cg4PFhCI6OhoajQbPPfcc/vSnP8HDwwP+/v54+PAhHjx4IHALk4o1a9YI9hsYGCjEebvdjrGxMeTn54NuThcuXMCf/vQn0RZ//vnnaGxslHGshYWFT647y8KFCwWQJHanVqulg9vV1YWSkhJs3rxZGgMkdnKwEHl47FCx08vGgpKwzInxyu6n1WpFeXk5ABcxmANUAgMDsXHjRun+qtUuHS7dYUj5UPricQASSddUkHCoTnR0NH71q1/htddekxKgvr5eSl5mFEp8jC17Yig8CUnDoKxOKXGjySj1wspTmJnV66+/LpwtLn7qhjm7mL/Dy8tLGksOh0NULuxePkq7YUNGOQuYsyfa2tpw+PBhaDQaLF++HA6HQ7rUVVVVCA0NhVqtlsHnIyMj8Pb2/g6JmeT1srIyFBQUwGq1il7UaDRifHxcMll2ZQkJcP4ts1R2LGkKy2bFxMSEQA2dnZ2yBtkUcjqdsFgsgkvm5OQgISEBa9euFSURnyEJ006nU6CEoqIipKWlyWxhPz8/aXz19PQgMTFRnJC3bdsm65jPl/pd6tDJ/SM1iA2rnp4e5ObmorCwEC0tLfjlL3+JX/3qV5LtEkOl4azyun79OoA5vS7Xp81mE0K13W4XWpG3tzeCg4NhMBiEc6jEKDk4Samx5ThTDuMiVWZychJOp1NKWsA1V7m5uRnd3d1obm52I2nzEL1///vJJE9E4KMDAwBxWSaWt3//fsTGxiI3NxcApN3Phx8TE4Pq6mqcPn1a8I+EhAQZIq1Wu6aLeXl5obm5WYIKAPmguEkJ5nKcIb/XYrFI2azM+JQLpK2tDZWVlTIflx1RADIPxN/fNeqQJSyJswAEPGbwVo5kBFylDBshLGmVFxc3sSHSeYqKisQan5gHu2TsCtPosb+/Hw0NDSgsLBQjARJpiRHp9XqsXbvWjWtIHIkbUVmOMhgyYLHLOzw8DJPJJAx9Xs3NzUhNTUVMTAyOHj2KV155RcwxGTCUJZ6yiUK1yfj4OF555RU3IvH4+DgyMjLEBHPJkiUisOf98t84mU9JllaON2Snkp51VB3wPoqLi7Fz506cOnVKXnv//v0AXCYWbArs3r1bMFmWwwwaLOe45jZv3oyNGzdKACOWlpGRIWT2+Ph4wWNp05WYmIjU1FTRzKrVahw4cABGoxEpKSmSBLARZjKZ0NXVJTQg6uWpt+Vn5HS6lCfknhKbIz6pnIBGjThfhx18YA7D5sX9SNUVAGRnZ4uLOeBKhKxWKxoaGtwcrwHIetVqtW5x5dHriQh8vBwOh2ROgCuYrF69GsnJyfImlFnFpk2bhN9UWloqWePAwMB39KtdXV3CVWKHjMA/MDcrgB+CUq7GRaPT6TAxMSGd10uXLgleRkCZWSBNUjnQmqUHMSLyDgnScmDP8PCwcNuUF4cBmc1m6dLxIkan1WrR3t6OkJAQ5OXl4fDhwygqKoJWq8XRo0eRmZkpGB2lelarFZcvX3bL2qghZoDhGEKdToczZ87gzJkz0Ov18PT0lECg/FnlwCEGK1JglI42Go1GKC3Dw8MyRyMnJ0dwMh5ISlxN2dX++uuvJdiWlZXht7/9LX7zm9/IHAvKofR6vWBnDGJbtmxxwx7ZvFESrpVYH9/PkiVLRBfMjiPfE7MqAKiurpYMadu2baIqqKqqkjkrAAS3oiaamSgAoc9wrGNiYqJgszS84LwW8lppQgrM0biAuUFUSska1yYPdOqwlQYAra2tbg035UwYYt8k0fNZcP1yfwCuSoN7iu+Pa0PZyFCr1ZKlK7O8CxcuiMMQuZY8nMgBpTTO29tbDHAfdz0RgW90dBQXLlxAamoq2traJN2OiIgQXy8AQj6NiYmR1JoWVcqLAdDhcMhpzD/M1lgCKcXp1EoSJOZm6+3tRV5entvv4TwQBg8uQI4MJIn50UsZkI1GI6qrq1FUVISkpCRREygF44ArozIYDIiPj8e+ffuQn58vr0FpGHlU/f39KCkpwWuvvSZlQ3p6OiIjI2VAtV6vh8lkwrlz54TbRkNOYjcsFQGIW3FnZyfS09OlhKe1ETcPy1gAEhC4wNVqtRw8nZ2diIiIgF6vR3FxMVpbW4UcraQJORwOnDlzBgkJCVi+fDmuXLnipusk2M4ytK+vT7qkxcXFYiMFuDIBfmYshZSZJgPqyMiITF3T6XSSUQBzml0lzYaBPzQ0VA6PwsJCvPTSS/K6HJ6l1WqFZE15naenJ2w2GyIjI/H73/8en332mZgVbN++HcePH4fZbIbBYEBra6vb81U+K2XWyisvLw8FBQXYs2ePHHgmk0mmGJJXSXgBmBvfcOvWLdV8cTgAACAASURBVAmA7GIbDAY3K3qtVit8TM7sZYOQIxOU0kHSU7RarZvxKknIpLvodDppbvLasWOHm9UXp9BR1/yo4gOYkwk+7noiAh8AcZdtbGzExo0bpXObkJAgdBGqGWJiYtyywMddLS0tQg0hPUKtVounmVISxkVfWVnp5pvGUplkUl4OhwM1NTXw9/eXSfNM9ycmJh4b8B69rl69KqcsBz739vaivb0dw8PDbrQNnU4ng8pXrFiB7OxsVFdXo6+vTz5cZgCXLl1CYWGhlBL79u3DgQMH5L0zAykpKcHw8LD8vFIixHKEcAHJo5S0GY1GN22q8udZurAUp9KCBw/vtaurS0pn4pFKtQ3nfSgdeHjv4eHh6OrqkqyCQQ9wGa9mZmaKON5ut8PLy0uGSTG4mUwmcT7hRc0p7cjoytLR0eHmatLY2Ijs7GxUVlZKt5ed7hMnTiAzMxPAHH+OhwiDPl+npqZGMsH6+nqhmwBAYWEhjhw5gqamJrf1ymfNCoSGC/zDIUE7duxASUkJ3n//fXR3dwu+S/MNXna7HY2NjSK/pFyRnxP3AAAZWs4uO/mP4+PjOHz4sKxVYI5So+SzcvxlX1+f4NXE15nIvPDCC9KtHRgYwIkTJ0SLTcyPDjbbt29HUVGRPFdCPXSIeeLpLA6HA2VlZSL3+u1vf4vs7GzhW8XFxcFkMiEjIwPR0dHo6ur6TtBra2tDREQEamtr3QbQNDY2yklDPIdsdADSHImJiUF8fLy0/ek+/LiLTHaK4YE5kJ04SFVVldt0ec6q0Gg0MrSIJQeNGXt6eiQQKXlrXIDp6emora2FXq9HXl4eTp48KSU04JLM8b5ZAig3ZHZ2Ns6cOSMCeZb9tMgKDAwUyyXKmnjqR0ZGilAegHADGRCVNBbleEgGcSVeCUAcUyj3m5ycxCuvvCIYFb8eGRmJPXv24MSJE/j3f/936fQq3VrYACLob7VasWvXLhQVFcHPzw9r1qyRjIXlWWpqqpvIPiUlRdxEnE6n2LZzJq3ytb28vESHqyzf09LSsHfvXpldoSQGG41GpKen4/jx49izZw+OHTsmxqGJiYnw9vYWXTfgonFxHdBhiBgys0zA3e1lfHwc7777LioqKoSvGRQUhNDQUMTHx0uThnAL1S2cepebmyt7hKoXZpLM1Bjo+NwdDofoiXNzc0VaSHoXKV79/f2iuKD+1uFwCL1IrVaL3vjq1asoKSkRnidliyzx6fd36NAhUc3wWSonzf23TQr+/748PDyQk5MjDsdvvPGG8OPYQFDO1J2YmJA6ngGQ388siuL9iYkJtLa2IioqCkFBQRKYUlNTZZQlL2o1uUlZfgMu3S4NENg9HR4exoULF4R5znKCjQJmTBSdExz39/dHa2srysvLZcARNzEpG/x/4pBmsxnr1q0TxUB0dDRqamrQ3t4OtVqNc+fOiVMML+JWx48fR0xMDE6cOCHBjHrR+Ph4mM1mvPDCC+jv78cLL7wAh8MhG42ZJEtE8uU6OjqECsLgBsyVxfz9DJhsfHAzXbx4UShBdrtdfr66ulo2e0hICHJzc/HJJ5/gypUrSEhIEB9Evj6bGsz+uDFJYVEGifj4eABzLi/smpKgnJqaCpvNhqqqKtlAoaGhYrw5Pj4uBwIDkN1ux/Lly6HVarF582ZkZmZKVcLJgHxvTqcTr7/+Ovz9/d2sxwgdsMP5wQcfyHsk3gpABg0pzQK42TMyMrBp0yYcP35c7o0BitPiyM2rrKxEc3MzkpKSxBSDzZrKykpJGoKCgiToEBaibIyHJvG5tLQ0GAwGDA0NCX0GgGSHoaGhgmky6eCaYOOCnFelC7rSAVqZjTNB4efJTBlwzc+22+1P/kBxlUolJyopCAMDA/D3dw3GVuJ+FotF0mhqBHmRs6UUqysdXWlF/Wi2qNS00pWEC4tkUC4Eh8Mh3S52Nnnv7JKSUpGUlCTYGOfksnzTarWSdXFzPupqrLRhok4yKChIyNkknh48eBD5+fkICQlxc9jgfdPUlWUKMGfrBEDs3kkzGBoaQk1NjciSyJCng8j4+DjefPNNfPLJJzIkW0lxAOboLMw62P3kc3Y4HPIMJyYmxAmHTSbiYZWVlfjss8/kGdCqSBlM+Jz49+HhYZSXl2Pjxo2oqKgQ0J7lnlarRWxsrJsKhhpaHkw1NTXIzc0V0rCy2cPSm8aeDocD+fn5oqtV3htxP7vdjqKiIvzbv/0bhoeHceTIEfzsZz+D3W6X0vXYsWM4e/asjJDs7u6WZxEYGIju7m5RSvB5m0wm5OXlobi4GIWFhZK5q9VqkR0SC+zt7UVJSQlsNpsQi2khxWHzwJy5BZ9nf3+/wB3K7imfycaNG3Hr1i1JNEi0V8Ib4+PjUorGx8ejqakJBQUFgnnX1taiqqpK1tmjEkKWsErHbNKN2OTo6ekRuldPT893GoTK64kIfBqNRsTlFRUVUKvnBoZfunQJNpsNr776qnjdqdVqNx8zOhYDrtOEGFtbWxs6OzvdtIP8Q/kabd85R4PAv1qtlu6vVuuayRoeHo5Tp06JrRC1wMRMqP+ldRUDKO9LidUQ36BihAuJi0lJ29Dr9Vi/fj0uXbokmkdSYQ4ePChlkdIXjRcDUEVFBQwGgwDqLPcJeDNYcqH19PTAz89PDhY2CojNfPLJJ2LIyZkdwFyWyYsLktkeAwsJ0Hx2zAiYHSYnJ6O3txfFxcVyMHA2A38XAXpmYfwaMwG73Y6cnBy8/fbbAFwdTovFIgYCfB0Gi9DQUDgcDqFulJWVISoqSoxGWQbz9zCz0mq1iI6ORnd3t2QoSjcUrVYrYvudO3eKHp2Y11tvvYUVK1bggw8+QHFxMS5evIgPP/xQOHikwjAb4ppPSUmBl5cX3n77bXElDwwMlMOLhqHEupuammA2m2G325GUlIShoSE0NzcjOTkZQUFB+OijjxAfHy9NNyWtijgaaVPA3GwSuqQwUI+MjKCzs1N+D7+Pa8Nut0tZOzU1heLiYvl9rCoopeThyXXMTJgGHhxKzkOAlYla7SLVf9/1RAS+8fFxeHl5obq6Wjpg1dXVeP311xETEyNBMCAgAPX19XIaq9Uu4wE6kzATzMnJQUBAwHfKZcAVSBlMkpOT5QSprq52m5kbHBwsYm5y2vbv3y+n5ZIlS8Q5hBgFhxep1WqcP39eTim6Y9BglQuHCzEmJkbKd+XFDWw2m2Vh7N+/H+Hh4SgtLcXOnTvR1taGrVu3oqKi4juD05ktKIMSL09PTyHgctASQWGe/rRV12q1UnL7+fkhMzNTPAaVtIZHT1iaSSoxP+U98BDj4cBSiuRcOu+wg0ksh6/N38dgp6Rg9PT0SHc+MzMTMTExKCoqAjBHWFdiWJQhMhOi/lTp7ssMjvQZHgYHDx7E7t27sWTJEvT394vBK4Mry33ijP/0T/+E/Px8vPfee9ixY4fgsg0NDRgfH8fevXvFbp5OyLdu3ZLuZUFBAZxOJ4qKiqQy4aGklHnx3zj/oq6uTuAkrVYr63/FihVoaWlBfHy86GWNRqM8L9qP0UyCvyM4OFiyN41G4zb7pLi4WIjgpKQQh1fuRY7KZLVDmgqrCK4LMg8SExNRVVUlDRJluc/smuNj/5Lz1BMR+Dw9PfHRRx8BmPPnJ0gcHh4uNlH08rJardi5c6c4vCYnJ8NoNH5vN5WuK0ajEUlJSTCbzfD398exY8fE3wuAm8tLc3Mz3nvvPQAu6Ryt10NDQxEUFIT169eLOwwz1c7OTgGWT5w4IZwwdg+ZZbEU4AfLwMMsT3nK0maf9JCf/OQnWL16Nd577z04HA4Rj+/cuRNbt251m4LV0dHhxtdS0mPYpHA4HNL55PNXmiEwC9VoNKiqqkJ9fT1eeukl+Pn5iVkoAJHKPdrEYPeV2KXyovUXyyDqmXfu3IktW7YgLS1NPu/U1FSkp6fjzJkz8vN8vUdJ0mw00Ul469atuHjxIgBXWU8Hb25mct9IdN64cSPsdrvwxQihcAMCkM91+fLl2LJlC/r6+rBy5UpxdmZVQH0pPf9ocGo2m5GTk4ODBw+i7dvRlVwbFosFr7zyipgT0FCBfoLsoDI7ov1Zd3e3BD2qJiIjI6UKYcfVZDKJ4iQpKUlYCi+//LKsSeKIgOsQKSgoEAUQM868vDxxMzpz5gzy8vJgNpuFGUAIiBeD3vXr11FdXY2mpiZ0dnaio6NDJivS3GN4eNhtjxDGIQ2NkI5OpxPVD6sXk8kk2PX3XU+EVvfIkSO/3rp1K1588UUsXboU3t7eiIiIgEajQWlpKb788ksUFxdjdnYWWVlZ+PGPf4z169eLO+z09DRu3ryJ7u5u3L17F3fv3kVVVRW++OILLFy4ENHR0Xjqqadw7949mcUxPT0tDhR0pJ2amsLly5exbNky5OXl4dy5c/jiiy9QU1ODoaEhPPXUU9DpdBgbG8Pdu3dx/PhxIUJ7eHjg+eefh7+/PxYuXAi9Xo979+5hwYIFCAgIwKJFi6BSqWA0GvHcc89h6dKlGBwcxNjYmKT/9+/fh9PpdNO4Llq0SO7x/v372LlzJ7Zt24atW7diYmICb7/9NhYuXIgjR44gOTkZN27cAACZSD86Oipa07GxMYyNjWFoaAgBAQGw2WyIiYlBcHCwuOFeu3YNExMTiIuLc9NSAsDDhw8xODiIvr4+/OhHP5IOK1+T74Uzblly+Pr6wumcmwnMAF9fX49nnnkGZrMZixYtkjnHb775JqamppCZmSka6uHhYTnYSAlhoJuensbU1BR8fHzk9SMiInD//n3ExcXhzp07mD9/Prq7u0VNQyE+Gf7R0dEYGhpCYmIibt68idu3b0Or1cr74BwOq9Uq82cB4ObNmxgedo0yVKlUsNlsopXl58hmAN1X/P39sWzZMhlgPjMzI9StlpYWPPPMM9i8eTMuXryIlJQU+Pr6ikXYH/7wB/T29sLHxweTk5MwGAwICwtzw9C8vb0xNjYmck1/f3/J2p555hmZj8yGxEcffYRnn30WKpUKPj4+aG5uxscff4z79+9LFr1o0SJ8/fXX8PPzg0qlEjYERy6wUeV0OrFs2TLExsbCZrPh3Xffddvrp06dwscffwyTyYSxsTE8ePAAaWlpuHv3Ljw9PaXZxHskzvzDH/5Q1uOCBQsQGxuLsbExwZ05L3lsbEwgqPLycuzateuxWt0nIvAdPnz41xs3bsSZM2cwODgocjWHwwGDwYC1a9fimWeeweDgIIaHh1FRUYGysjIsW7YMq1atwuDgIJYuXYr29na0trbi/v37mJ6eFq3k1NQUzpw548YLowuGl5cXbDYbbty4gYULFyI5ORmLFi3Cv/zLv8DpdOL555/Hc889h4ULF6Kjo0NsgAICAsR+ftmyZQJgd3R04M6dO4iLi0NqaqrgP3FxcQgODobNZkNpaSnKysoAQNxmb9++jb6+PkxPT8uGYUnFgdQ2mw3Hjh3DqVOncOvWLURHR+OZZ54B4JLyeXp6iqECMNfECQsLQ0BAAKampjAxMYH58+djdHQUPj4+Mlx7dHRUStKBgQEsW7YMAQEBmD9/Pjw9PREWFobZ2Vk4HA6cO3cO7e3tmJmZQWNjIzQaDQYHB8ViipmYWq2Gh4eHvAcG4Onpafj7+yM5ORk1NTWIjo6Gh4cHNmzYgAMHDqC/vx8PHjyAl5cXPv30UwwODuL+/fv48ssvsXbtWhH2A65B8IsWLYKvry+++eYb+Pj4wMPDA1NTU1Cr1bh37x7u3LmDiIgIOBwO/OAHPxDs7N69ewK2szzlQPmZmRkEBATgwYMHAFyNgZaWFkRFRWFgYEDeI80X/Pz84OXlBZVKBa1WK2twenoaixcvxtWrV+Hh4YEXX3wR9fX1ePfddzE4OCiD1u/duwebzYa0tDSkpKTAYDBgcnISn3/+OQYHB2G32/H5559j4cKFkm36+voiJCREXEi8vb2xcOFC9Pb2or+/X7qz5BEaDAbU1NTg6aefRmxsLKKjozEzM4PPP/8cL774Ih48eIAvv/wSf/jDH3Djxg1MTU3JXAvAZS7h4eGBkJAQLFiwAP39/VJpcf0nJiaiq6sLpaWl2Ldvn+zxlpYW/O53v0N7ezuWLVuG//zP/5T13tLSgoGBAXh4eEjzZGhoSExE2Dm2WCzw8PDAqlWrcPXqVdEDj4yMYGpqCiMjI5ienkZvby/6+vrw1Vdf4R//8R+fXJMCLlIlUbi0tFRSXpaT7FAxgChLKJasHKAMuAJnbW0tkpOThaPU1NSEhIQEKXUmJibEzy4yMlI4ZwUFBVL2Ep/S6XQyFpEpPDlRxLhSUlKg1+u/M3hISW0hvYV4Ymdn52NZ5ix3NRoNenp6OBkeQUFBWLNmDcxmMzZs2IAPPvgADQ0NSE5OxquvvoqhoSE0NDR8x0RACRBT7UB6hMFgEBXByMiI+B/SGtzhcECr1Qq9wWq1CpeR9AVlN5OBQVnisoTn+yLozebRm2++Kc+aADkbIQaDAYmJifKzLN/ZzSUsQOI31R1sZExMTEiJp9Fo0N/fL+oM/pvNZhPpIDWfOp1O1D0c1ERtMtfnyMgIEhISkJiYiLq6OpndwslywBwHra+vD6WlpfDy8sL777+P9PR06PV6xMfHSwcegNiBtba24sqVK8INDA0NdcPx2tvbkZ+fj7KyMjFxoJKktbUVa9asQUxMDMrLy6Vr+8orryAiIgJdXV2iKOHeqKioEPI3jVe9vLwQFRXlRgDnc9ZoNIK3qtVqDAwMQKPRCAkZcNHCKisrpYlZUVHhRglTDhMH5iSYSgYATU5jYmJgsVgwOTkJm82GxMREtLa2Ch7PJodyVsrjrici8AUEBCA6OlokLhcuXJAualtbG+rr61H//zD37kFR3mn2+Gm5NNfmDkKDIE0k4ETBhAAbBDULWTOQn1m04jLZzcjUZENqJtl8Jxc3UStr3JmMIZUYd6I7mdFKKhpnhEoixigMk4AawAugaCMILZduaG4NNNduGvj90TmPb5vJ7G59L+VbNTUGmu633/fzPp/nOc95zqmvh6enJ2pra+VhBW4PJ4eGhgrnDrjthUGFFqWPg16vR3Z29ndG3ZQHz4UHidOU+DaZTKK4omy9GwwG1NTUyINJxj9Z/PTJJQF38+bNaGxslABPcq5a7VScpSHOuXPnxMj8zJkzKCwsxM6dO3Hu3Dn09vaKKMLFixeRl5eH1NRUHDx40IVWolarhQJA/htlzOnLoJyZpLH36tWrceXKFaHFFBcX49ChQygpKUFAQICLkq+Sv6XUWlMGXr5Gq9WisLAQer1eDNwZzIiV0YQ6OTlZHNSUpja87kq8j+/PoEl8jZ8FOLFMPz8/cQNramqS4EK8zd/fX7hn7F7yPimzWrVaLdMOqampIhTBe6zT6YQ7GRoaiuDgYGzZsgW9vb1iO7p//35s27YNgLN7W1JSgrKyMpw9e1aCMLlzfn5+Yn5VUlKC2tpaeQ6GhoawbNky9PT0iIXA119/jdDQUOTn58soJi1NWQK/++670rhjp3pwcFBIz8pkYXh4GElJSS6bEy0ZlFSxvr4+vPfee0hPT5eS9auvvnJpQiUlJQl/lkkH6UMU0+BnEHf08/NDUlISKioqBHfk909JSXEhWH/fcVeUuh988MHrTz/9NDw9PWGxWBAaGgqNRoM//elPeOedd7Bq1SqsWrUK165dw+DgIG7evImuri5MTEzAx8cHBQUF2LBhA8LCwnDr1i188cUXSE5OFo6QWu1kznd3d8NsNsPd3R2tra3o6emBh4cHbt68ibNnz6KnpwcDAwO4du0a/vCHP2BmZgY9PT24cOECbt68CZVKJVgZuXTt7e0ybTA6OipgLR++/v5++Pn5obu7G8PDwwgODpZSb3h4GGFhYbh58yba2tqkNJqenkZQUJDgZadOncKOHTtQX18Pu92OFStW4NKlS3j22Wfxxz/+UWaKNRoNpqenBVSOjY3FpUuX4LRBgZRELKX5QHJRORwO0aEjfmaxWGCz2dDe3i7nFxAQgKysLPzDP/wDysvL4ePjI7xClm8AkJGRAYPBICWu8rMBp+5bQkICfH19cfHiRSwuLsJut6O/v1++5+LiIv785z/j2rVrMBqNWLZsGdrb2+Hj44OpqSnRQnR3dxd9QGJV1KszmUzw9fVFRkYG6uvr0dDQgOnpaUxMTMBsNsNms8HX11feZ3BwEFarFe7u7oiKioLJZML09DT8/f2hUqnw/PPPo7m5WbJZPz8/mM1mWK1WrFq1CufPn5fucFBQkKgtR0RE4O233wZhnZMnT4qg7MaNG2EymaSBxjGthx56CGazWZorOTk5uHXrFkZHR7Fx40aMjo6io6MDU1NTiIyMxOjoKMxmM8bGxpCTk4PKykq89tprqKmpwfT0NOrq6pCWloaPP/4YVVVVMBqNMBgMMJvNon+nUqlcqgQ3Nzd4eXnBYDBgdHRU7qGXlxdaWlpgsViQlpbm0lysrq7GJ598Ig0VmqOfP38ewcHBGBwcFKjJbrcjKChI1mhgYCD8/PykK2u32+Ht7S3iBnRuy8zMFJoR7xE9eYOCgnDp0iW8+OKLd2+pqyTu6vV62T3pCMaZ2JSUFJcJCZ1OJ3gOwV2dTofExEScOnUKtbW1yM7OlvLp+8bQ4uLi5DVM4Vl2KGkTw8PDiI+PR01NDVpbW7F69WqXYX6Wgv7+/rI7Tk5OunSqenp6hGeltJwEXCV6wsPD4eXlhf379+NnP/sZJicnpdWvVqvxySef4MMPP5RSmgrJGo0GjY2NUsalpKS4cKS4M5KQqixFSY4l658TFcw6gdvl944dO3Do0CFRhCFFR1lqVlVVuZQs8fHxLlMWk5OTKCsrE5Cf10mtVku2QVl8rVaLZcuW4eTJk0I3IZ7I8kt5DkqyMTMJag4q6RGcLAAgGTk3rc7OTuTk5IjSNPl8nKBQEmpZXh05cgQxMTESOG7duoX8/Hx4eXnh6NGj2LJlC/R6Pd588008+OCD6OzsxNGjR7F161Z88cUXQu/JycnB+++/j8zMTOnK8jPS09NdxjIBJ0eRkIvN5hzLpIk8M6DW1lbo9Xp8/fXX0Ov1mJubEy9qXjvSr6iNRy+M3NxcNDU1CTuC78lRvztpKkajUebXm5ubJQDSQ4OZHDvrXF8eHh7SXQeco4wUt6CjXlRUFK5cuYKIiAgZeqirqxO4g2vprhcpWLJkCdra2mA0GnHy5Elxn3I4HII70HH9Rz/6kfyd0WhEaGgo/Pz8XMpSAMLgZmBwd3eX8rWvr0/KXIvFAsCJRXFKY2BgABcuXAAAFBYWipdCfX29zCXSXJnEUHqfAsD69etl7IpYoN1ud2HGK2V7OHbG5oBWq8Xg4CD27duHhoYGXLlyRQBeTopERUXhwIEDCA8Plxlncggfe+wx4chRKPXo0aPCk2MApRwUSc/KwMjPUXLeWL5ysZIm5OHhIRsPvwezBeA2d+/GjRsyxcGyjXAAZbquXLkiDyFNfCiaQCMcngOnUTgVA9wuPZVkVz4cpE8op0uUwpkA5L7zKC8vl9fTyjEnJwdPPvmkvD+vGb8vTaDCw8NFcOHMmTN47LHHYLPZZHRy2bJlKCwshNFoFB7d8ePHZcPdsmULjEYjOjo6sHnzZimpWababDZRJ6+srJTZbQaK1tZWLFu2TJRgbDan7SJFAwDnBpufny/aiwz80dHRyM7OluZIVVUV0tPTkZubi4yMDLEE4HABj/379wsswE4211VFRQV6e3vFsjU6Olquk3KyBrity6eUuqqrq0NUVJTQtbRarTQblSK+/Lu7XpZqbGwMgBOTeemll2AymXDs2DEpV+/U1uNhsVhgtVqFu6bcdeLi4kTBefv27UhKSpKZQGKHxFsAJ87IzI2euFarFVFRUWhraxNVi7CwMBw+fFgcrYDb418UK1WrnRpy5JLV1NQgOzsbWq1W5mnJpq+oqJDPUhKAS0pKZB6RAPKHH36Iffv2ISQkBKdOnUJMTIx4GOTl5SEgIEDmnKurq0X4tLe3F7m5uSLcyKDHnVYJqjOoKDMvYpIMaNRK27FjhyimAK5eFQwWzLb4/ZRBBwByc3MlI83JyYHdbhddOeJNarVziobz0hyHIlzA68bynJ8RFRXlMjtMvE75+ZQ2V45ucUKDeCdNeY4ePYqioiIMDw+jsbFRHlw2X/j9OHbV0dEBu92OF198EXv27EFubq4Qe+fm5oQnuG3bNlitVqSmpsJoNOLChQs4evQokpOThftpMBiEJcAApsy0amtr4eHhIURrJW+wo6NDXNModMD3oY6dcpwPgJCKJycnhfNHHmxtbS0aGhpcfK67urpw6NAhZGRkCP+STbOhoSH4+/ujqalJGhnKTJwVH68b1ca50ZPQzipIuS6IW1MHMTMzE2q12qVK+UvHXRH4HA4HDh8+LIThqKiov1iWXrx4EQBENr6yslJSc15AfnGl+AAH7mtqaiSF5ihWTEwMnnnmGQleqampKC8vl4Foq9UqQo4AxOGe2Qofqs7OTrS2tgrwzJ2ZnVvuouzuApCOolLIUzmNwIyOx6FDh1BYWIiUlBSsXbtWdk2Kk65fvx41NTV46aWXJLMoKCjA7OyslJ3sSLJzx7lTpZub0rOWCxSALFqaG4WHh0sGFh4eLg+6Mvgx0+AiZZbA92WgBSAQR2ZmpgDyJ06cwLJlywBABA0YAFk2MVPmteOCZ0bW29uLvLw8GSnjfR4eHhb9t4qKCum8ArcbI3a7HampqdDpdKiurhaVEb1eL6NndXV1GBwcRExMjAQbBpCBgQGUlpYiJiYG5eXlAofwO2/evFnk7JubmxEfH4+UlBR0dHQI1JCQkCC+0lQROnz4MOrq6oS7x7liq9WKmpoaDAwMCK9u5cqVCAsLw759+0TeDHCWtampqSJaumbNGmi1WlHHYUAiAZvGWwBc9PJKS0vlN3P/mQAAIABJREFUPWnzADgz5JycHPmZkpC8fPlylyaUl5eXfM74+Lg0snp7e13EXkNCQrBs2TLo9XrU1dXJnC6zUvp8eHp6/lWRgruiufHrX//6dQKa99xzDywWC3p6erBkyRJcu3YNfX19uHXrFq5duyY6eyaTCQ899JCQTx9++GGkpaXBbDYjMjLSRcvf19cXbW1tiIuLw9zcHObn52V2VtktWlxcxNmzZ2G1WuHt7Y1Vq1ZJ8OKiIki+YsUKrF69GlqtFiqVCiqVCp999hlMJpPgL4ODg7h16xYuXboEo9Eo50iM0t3dHdXV1UJkVsro2Gw2REZGirGOw+HA4uIiXnjhBfzpT3/C9PQ0+vv7hQrU09MDjUaD2NhYABDc88KFC9BoNGK8tHTpUvj4+MDDw0MMfZRBw83NDWaz2UUcgdw7BkMC3CqVSgB1q9VpxEPjGwa7v9TYcHd3l+86ODiI1NRUaRyZzWYsXboUarVa9Bfj4uLEAIfmUJ6enigoKICvr68A22xm8PoBEApRWloarly5ImTnmZkZaLVabNq0CQ0NDQgICMDSpUsxOjoqPD0C+5GRkdi9ezf27NkDlUoFs9kMHx8fBAcH45lnnsHp06cBOMU2aHDk6+uLc+fOYeXKlYiJiUFAQABaWlrg6+uL0NBQBAYGwt3dXQx4YmNj0d/fjyeeeAKnT58W50FPT0/ExcUhODgYH374Iebn52EwGLCwsACz2SxOeGyQXb9+HSEhIYiNjcXk5CQsFgsSExPR0tIClUoFu92OhYUF+Pj4iLtbaGgoMjMzpalksVik4bCwsCBE4xs3bsDLy0uC3uTkJD788EOBWNzd3bGwsIAvv/wS0dHRyMrKko2/v78f3d3dmJ+fx6pVq1wYAJzE4EFuJJV/OH/v5uaGyclJmM1m+Pn5YW5uTvh/arVamhuEzW7evIlf/OIXdy+B+de//vXrBL49PDyki2U0GhEcHIzR0VHYbDbpXHH3Y0ePDwk5evQz5XHr1i24u7uLcADLpNdeew3BwcHSHYyLi0NsbCxMJhMWFhbQ3d2N7u5uXLx4EY2NjXBzc8Po6KiQQW/evInAwECMjo7K7CJne00mE3x8fDAxMYHg4GDJAufn55GXlyed2IsXL2Jubk6czubn5zEzM4PQ0FChz+j1eri7u2Nubg7/+I//iLGxMRiNRszMzGBqasqFV8VucHBwMCIjI4WAu2LFCgwPDyMyMhJr1qzBhg0bpEF0/vx5qFQqBAUFwWazQaVSweFwwN/fHwEBATCbzS6Zq6+vr3ghj46OwsPDQ1j1np6ecHNzE8UdLkhOO7A7Sk4fscUNGzbAbDZL93vTpk24dOkS4uPjkZycjIaGBqhUKlkLYWFhmJqags3mNO1xOBxwc3OToKs8nnzySbS1tcFkMqG/vx/u7u4YHh7Gxo0b8cc//hEWiwXR0dGYmpoS6bGEhAShtuzfvx+vvvoqrl69iqmpKUxPT8PhcGBsbAzJycnIyMhATU0NfH19hUgbHR2Njz/+GGazGe+9956Y8lgsFszNzUGn06GwsBCHDx+GRqNBX18fnnrqKQwPD8PNzQ0+Pj5wOBxCtg4PD5cJlmvXrmFubg5PP/003N3d0d7eLhM6ISEhSElJwa1bt9DX1yfd3cuXLyMkJARdXV0ijsD77OXlJZvd1atXpdM9ODgoXW5e18OHDwNwlra/+tWvUF9fL6Tx8fFxjI2NwWKxiJBscHAwOjs70d7ejoWFBbi5ucn68fX1FdfAO6lOFIEIDw+XjVJZHdCygEZMHHnkZ5HC9uqrr969gW/v3r2vs7Xd3t6OpqYmechaWlpw6dIlTE9PIzk5GYmJicL54xA7dxtmDJz7A5w36N1330VtbS36+/tl5IrOaDMzMwgODkZ7ezsaGhqQmJgIT09P3LhxQx5ylUqFxMRETE9Po6CgwIXaERkZiZ6eHnR3d4vBy6OPPoqGhgbY7XYZTXN3d4fJZEJHR4fIrjc3N+Py5csYHByUyQM3Nzc88MADePzxxzE/P48NGzYIs7+6uhrHjh0T0QWdToeenh6Mjo5KVshMmNfvgQceQEhICMLCwvDAAw+IA1h0dDSSkpIwPz+P++67DxaLRc6TUlNk6jOLYTnO0bTY2FjMzc1h2bJlQqNQq9UuCipc1DabTQI7R/FIR+IDuGHDBkxPT+P69evSFGppaZHRsfn5eXFiA5zYbU9PD3p7e+V+MDOdn5+Xh6yoqEisNfmdHnjgAWRkZCAjIwMJCQky7cCsgZ81NTWFtLQ0fPTRRyIeazKZMDo6Ch8fH3zzzTd44okn0NDQIJgzKTTMjEdHR1FUVCQZ+meffYaxsTG8/fbbMJlMcDgcuPfee2V6pri4GMeOHcPo6CgiIiIQERGBiooKpKWl4ZtvvkF2djauXbuGlpYWbNy4EadOnYLD4UBcXBySk5Nx6NAh2cRSUlJw48YNtLe3w8vLCz09PfDx8YGXlxcGBgYQExMDNzc3pKamClbJ+6hSqTAwMACVSgU3Nzd89NFHAJyQ0+9+9zsMDAwgLCwMY2NjCA4OlumViYkJdHV1obu7GwsLCwgKCkJXVxc8PT3h7e0NAJIoaDQaREZGytoNCgqSZt/8/LwEdZVKBYvFImOWVPFh9me327G4uCjQit1ux9jY2PfaSy75vxTL/kfHzMyMAJbEAKqqqkRdQ8nSHxoaQmlpKSorK1FQUCCt7MOHD+Pdd991GUzmAL5Op8ODDz6If/mXf8HmzZths9lQU1ODPXv2SLe4oKAAO3fuRGhoKPLy8sTbk4oYlOVmA4Oq0H19ffIzls7BwcHIzs5Genq6SIF3dnYiKSkJa9asQXx8vHRTZ2dnXSTQ+T42m3OAnAFkzZo1qK6uFn6X0WjEmTNnXCz6iHNS2stmswlORNFQNmHq6+tRVVWFiooKWK1WlJaWCuWATR52b4nVETOj2q3BYJBuGn/Ov+Nxp+Q8P4PkZsBJYejo6BAc8kc/+pHAASRZ8yC2x0yR70vC9532k7xn7B4CzgwwICBAzMyJFZFeZDQahSR99OhR7N69WzBRKgsT/9VoNDhy5Ajy8/NdiM3AbUUXo9EoFpnbt2/H1atXceLECdhsTvFTJX0rJSUFfX19gkVTPIHTNM899xyGhobwxhtvYHBwEEajEU8++SQAZxYUFhYmHc+IiAhs374dTU1N8PPzw8DAgDjqmUwm+Pn5ITQ0VChDCQkJMBgMgttSv9HDw0MUVq5evYqjR49iYGBAfDZ4HtQW5H232WxCdZqbm8PIyIg0YAICAsQ0nUGQFCEexL7ZaOOaMZlMiI6OdunmE1dVZo5Llnx/eLsrMr4333zz9eXLl0vGsWTJEjz11FMyGrZhwwYYjUacPn0abm5uePjhh6W7+uGHH6Kvrw+Ac+EUFBRIh+o///M/ERcXh7S0NLi7u8PX1xdHjhxBV1cX/Pz8MD8/D7PZjIaGBkxMTOCzzz6D3W7HpUuX4O/vj02bNmHp0qWYmJhAf38/rl+/Ll3R7OxsLFmyBDdu3BDuFYUPbt26BV9fX8nEmOmQYsKOW11dHebm5jA7Oysk43vuuQcvvvgisrKykJSUhLm5OXz55Zc4cOAASkpKoNfrYTabcfPmTQQHB2PVqlVYu3YtkpKS0NLSImUhh79HR0eFXkByMidM9u/fj0cffRTT09N48skncc8996Cvrw/Dw8MSQEjsVQLFdrsds7Oz8PX1xaVLl6DRaLBkyRJ4e3sLL1Cj0QhWw4ycgcJudxqku7m5iVad2WxGSUkJWltb0dXVBbXaqbTR1dUlajbT09NYuXIlzGYztFotvv76ayQmJgquOj09jYiICMmc1Wo1Xn31VcF7LBaLiBKwMWA0GtHS0gKz2YzW1laEhYVh27ZtuHTpEuLi4lBVVSVCBOy6Motl+Xf58mVZJ1NTU1Cr1QgODobFYsH8/DyCg4OxYcMGGAwGbNy4EdHR0diyZQvuv/9+PPvss9i+fTtKS0vx+eef449//CM++ugjFBcXY2BgQIQW2ElvaGhAWloa9u7diwcffBDXr19Hd3e3zLf39vbCw8MDCwsLCAwMxOeffy4ddZqQ9/T0AIDARUFBQejv75epiqGhIQQFBSEoKAhZWVl44403ADjHSH/zm99gZmZGFMa5nghFcXNlZs1rQkNyHx8fSUh4nYaGhtDf34+IiAjR2AsODoZKpUJ0dDTc3d1hsVgQGRmJFStWiGgGS2YS1x0Oh8z/ajQajI2N4bXXXrt7S91f/vKXr3PY3mazCYhNT4r29nYkJiZCo9GgubkZNTU10nllR9fPzw+BgYFob2/HzMwMrly5IjLxOp0OoaGhePvtt1FfX4+QkBDMzs5iYWFBQPPu7m74+voiLS0NRUVFgj0ATl/PrVu3wtfXF1999RX0ej0mJyeRnp6OGzduwGg0Sgnt5uaG7OxsfPbZZ7JTETs8c+YMNBoNwsPD0d7ejps3b4rp8fz8PDw9PfHYY4+JWQ3g5Dhu3boVx44dQ01NDcLDw/Hqq6+isLAQCQkJ0gBZWFgQcjeZ8aOjo8jIyMDFixfFVayhoQF9fX347LPPxKnq5ZdfhqenJ86cOYOZmRkJVsHBwVKiOhwOzM/Pi18qmy8RERFwd3fH2NgYQkNDpbwbGxuTsnb16tUuZR/pDAyAgYGB0Gg0MsgfEhIimSknXbKystDd3Y2ZmRnMzMzgoYceEgHX6elpkRonq5/fIS8vD+fPn4fZbIbD4cDKlStFTuyhhx5Ca2urDLXzITUYDOju7sb+/fvx8ssvw8vLCw6HQ5gAfOAAyCSP0WjEihUrpNFDZRy73Y4vvvgCiYmJ+Nu//Vv85je/QWVlJaKiorBq1Sr09fVBrVbj/fffR3NzM7q6urB582YAziDHZsuGDRsEu1q1ahUWFhZk0oIeFmxU/dM//RNqampkTXZ1dSEwMBDz8/Po7+9HcHAwvL290draKkGMyiYeHh7w9PTEzMwM7rnnHjz33HMAnHL4bNIR1pienkZwcLBk9ErBBmLnAKTh5OPjg4iICGnYEEKZmpqCl5cXRkZGpAHi7u4u64yNDDaEVCqVjCKyIvH19YWfn59Yv87Pz2Nubu7uVmfZs2fP64GBgSJzbrfbYTabceHCBbS2tiItLU3KXC8vL2zcuFEu5gMPPABfX18XeaFbt26hpaVF5voqKytx6dIl3Lx5U15HnwUPDw+5cPQ3CAsLw7lz50TZ48svv8SxY8cwNjaGjIwMREREIDAwEPfffz/6+vqkkTE1NYXCwkJ88sknYiBO8DkuLg5ZWVmIiYnB/Pw8urq6YDAY5OEAnAvj5z//uQgDAM7FxOaM0WjEkiVL0NLSgsnJSVy5cgUNDQ2oqKiQh0IpfkmVGG9vb5w/fx5dXV0i0Ont7Q2z2YyBgQF0d3dj/fr1+N3vfoeNGzdKaUvclA8ypZjYlFi6dClsNhtmZmakYUBqDLNcdiEZKJTvw+B57733Sqc+NTVVSOVarRYLCwtISUlBUFAQOjo6ZPysqalJun3Lly/H0NCQKJUwI6OPBIORzWZDf3+/i4H24uIihoeHXbrqQ0NDqKurw6ZNm2QTYZZBDJBgOu9dU1MTqqur5bspN4vGxkYUFhbisccew9WrV/HRRx/hxo0b+OlPfyqvj42NlVHF3t5eUa0hNkY17ObmZuj1eulo63Q6GfkzGAxYsmQJMjMz0dLSgsTERAwODuL++++H2WyWcnBwcBBxcXFYvnw5rFardKrVajUWFhawsLCA1atXi9BAaWkp6urqMD8/j4mJCURERCAuLg6hoaFYWFiQQMN7DgCBgYHiZqdSqdDe3g4PDw/BF4nzhoaGSkk6MjIiTRpWGnxGASd84XA44Ovri4WFBfj6+qK/vx8hISGYmpoSQ3Y2vKampr4X47srAt/evXtfj4uLk8kHLiY6MFH/zsfHBxaLBYcPH0Z9fT26u7vh7u6OiIgIJCcn47777oPD4UBLSwuKi4uxefNmZGVl4V//9V9ht9uxadMmkRViykymu4+PDyIjIxEWFoYjR45gZGQEq1atEuHD8PBw9Pf34/z582hpaUFBQQFCQkJQWVmJoKAgzM/PIyMjA6OjowgLC5Mbp9E4jWVWrFiBI0eOIDIyEoDTBtFms8FisQgFJCYmBitWrMDnn38ODw8PTE5OQqNxmgXpdDoJlMoZyZiYGDgcDty8eVM+c9WqVYiIiMDo6Cja29tx3333ITg4GF1dXfJAdnd3Y3p6Gj/72c9QV1cHb29vREZGCvWFnL+5uTnRdmNDgiWzh4cHxsbGMD4+LgGHGwgAeRCCgoLknjJD4sJ3OBz4wQ9+gMnJSemqMgsYGhrCwMCAZJ0eHh5Cou7u7kZ0dDSKiopQW1uL7u5uAcFZgm7atAlDQ0MwGAzo6uoCcJvUzPKIBFulnBY7rocOHZIHuaenRx46T09PobTMz8/j+vXryMjIwCuvvILGxka5Rux8e3h4wMPDAzqdDps3b8b777+PL7/8Emq1U2W6qakJBQUFeOKJJ3DixAlcuXIFDocDQUFBkrVptVqpQCYmJjA5OYmbN2/CbrejoKAAERERwiJoamoSZsHAwACsVquU3dzEOjs7MT8/L2NpS5cuFfZAdnY2tm/fDsAZ9Gpra0USijPIKpVKZKCY2fH8uP5iYmJk/li5aQIQzUB3d3f09vYiMDBQusl8T1ZzLMW9vb2FvkSeJTdcAN+Z3R4eHsbOnTvv3sD37//+768vWbJE0lOLxSLaca2trTh37hyuXr0Kg8GAJ554AhkZGSIllJGRAV9fX3R9K1rg7u6OjIwM8enMz8/HzMwMOjs7peQhuXFubk66QREREWhvb0dwcDDCw8OFP5eamirilXSAy8rKwrp16+Dt7Y3JyUkRIW1vb3eRU1dORdjtdmzYsAErV67E+fPn0dbWhuHhYcE16RQVGxsrOnDkA46OjuLYsWOIjY2Ft7c3vLy80NbWhiVLlggNgeos4+PjaG5uhkqlktKzvb0dDzzwgNAzRkdHoVKpkJubi9OnT2PXrl3IysrCV199hbCwMFRXVyMtLU0ERr29veFwOGRn9/HxkSw5MDAQS5YskV18ampKqCUU8eR3VHZ6bTabdIfd3d2FkmC326HRaKBSqVz05iiZbjabUVRUhI0bN6KgoACjo6MICAiAw+EQTUCW5GvXrkVjYyNmZmZgtVoxMzODsLAwuV/u7u4CvpOGU1RUhA8++EB8dz09PREeHo6EhAQJ2sQPZ2ZmcP36dVRXV2NmZgbt7e2SARPrYzDIyMjAl19+iaqqKuk+tre3Y3p6Gg8//DB++9vf4je/+Q20Wi2ysrKwsLCAzs5OrFq1CmazGSEhIWhubsbQ0JDo1hGnvnz5MpqamnD58mVs2LABi4uLsqZ0Oh1aW1vhcDgQFRXlgj0Sm7NarRgdHYWvry9+//vf49FHH0VfXx+OHTuGsrIyUR/nBA7vo8PhkAxNo9GID/Hc3ByGh4dhNpvR1dUFlUqFpUuXIiYmBiMjI2K+TurU1NQUBgYGJDDHxMTIhAaJ04CzWpiYmEB3d7eLCAS5rADkbx0OBwYGBu7ujG/37t2vk7TK3YOYHS/azMyMdN2Sk5PxN3/zN0J94Q6empoq3LS3334bRqMRy5cvh7e3t4wrkWdFALi/vx8eHh7QaDQwm80wm80ICwuTBsTPfvYzxMXFISkpCT/4wQ/g7+8PrVaLtrY2hIaG4tatW3jooYfEjNxms6G7u1u0A4ODg/HAAw9I2UmgnV0wZWfS3d0dPj4+CAsLw7Vr1/Dzn/8cu3btwp///GdR3DAajYiMjBReF7PL+fl5DA8PIyQkBBqNRriO7BjevHkTiYmJLtfJbDbDaDRi+/bt2L9/P2praxEbG4u4uDjJ+GZmZgQHJU1ASR9i4PH29pZFzAdDpVLB09NTqCjE3SgY6uvri76+PqSlpWFmZkbAbLPZjM7OTrz22muYmprCn//8Z4yOjsLPzw9Wq1VUuQcGBjA+Pg4/Pz+ZVWZJmpGRIWo95O719fVh6dKliIuLEwrNV199BW9vb+kIq1Qq/OpXv5JMj5xEDw8P4ZH6+vrCbDbj+vXrmJycxN69e2Vzo50kaRazs7MC3oeEhMBsNovKCNWlz58/L5u21WrF5cuXMTU1hZmZGQQGBgrZvKOjQ8pAUkGKiorQ3NyMiooKKSkBZ9ZFcvnw8LA0CJiRE4dVqVRSwjY1NSEwMBBdXV04ffo0KioqRGV7cXFR7q1Go4FOpxMivJeXFywWCzZt2gSTyYTu7m54eXmJXJqbm5sQxyMiIiTgcmpoYWFBvpfFYoFWqxX+rru7uwRvUlyogZidnS2q4ADk70lq7uvr+96M764YWVOpVC7kRVIVKPzIi02lB84NKgmNBQUF6OzsFCqEyWSCwWBAfHw8MjMzZXCfclIkO7JbxlY8KSwhISF45plnXHw9lUdnZycSExMFzOUwP8eESPlQuqrxoKmNch5VKX6Zl5cHjUaDtrY2xMfHo7GxETExMeLVSgPs9PR0hIaGysLn92XQVlKBxsfHUVdXh8zMTJHkWrZsGXJycuS8lEo2pHUMDAxgbm5OrjOvPYF1AOLHe+HCBSlzGYDYyeW/gdvqKTSoqaysRHp6ulAjtFotkpOTcebMGYyMjAh2QyMiDw8PLFu2TM7D09NTXOs4t039OKV+nqenJ3p7e2WsMCAgAAcPHkRYWBj++Z//GcPDw/jiiy+ERsS5ZA8PD7S2tkoZPjg4iOvXr6OtrQ3PPfcc0tPTER8fj3Xr1qG+vl5oF0pj8ZGREaGmcK2TpqKcceY15oy2yWRCcnIyBgYG5Pec6sjJycGOHTtEnonCpyR4A05FFs5Tc1yONBWOIKrVahm/6+vrw6FDh2R+mvdRaeFptVpl7pY/5+ibUu0nPDxcFH+4fnp6eoQuw8BIgQ/e68nJSfHNttls0rXnc6p8Bvka5bgiqVd3vaE4Wf40JGYazMVDOkNqaioaGhrE5yI/P18ecC7wyspKIZoSv6DYZmhoqChLGAwGKYepDPHKK6/g+PHjMguampr6vQZGjz76qHQHgdtepBqNRhRQyD+Li4vDqVOnEBcXJ4GQjmq8oQTMMzIy5P0/+OADmT/mvCJne8fHx1FWVoaOjg7Mzc2Joi07jxR+5IOQmZkpQ/FJSUnSDQsNDcW5c+cwPj6OZ599FoBzcTFgcVidckEARHIJgJhtnzx5EgEBASJnpJzZpYqK8sHmZMq9994Lq9Uq94iD8eSTUVqLEkxUY/H09MT4+LhsIidPnnQZ0md2CsAlq7bb7RgZGRFl4n379sk9GBgYQE5OjohCaLVaCT78XhqNRnybtVot9uzZg/LycrS2tmJkZEQ8lfmw82+UPEGuVV4Tfv6d583rx4DJWVbKVHFj5WbLh54SVbOzs6KqreRj8qDiD+Ebi8WCo0ePunBhGZSpaE3+otLw3svLS4YOaPFI7Jznz+dEaWAF3J6Z12q1CAkJwZUrV4Sjp4wBFPxlx57PTkBAgMhk8TqRT6oUpbjzuCsCH0FMZQrMm0mSL0d+AGfDQLmz6fV6ZGRkSFBU+n8SCOUOazKZEB8fLwRVSkWNjIygtrYWW7ZsQW1tLfR6PV577TXk5OQgPz/fRfaqtLQUAQEBSEpKgs1mk87u0NAQZmdnMTExgdraWgwNDYm/6eOPP45z587J8DfJxsBtAm5eXp7wsfr6+kQavqysDABcCJ4mk0kk1KkqzffiNVUKKhiNRuTl5aGmpkY2gObmZuTk5ODQoUMYHh4WxWoGWY1GI+bUlMrn7+jrS+kog8Egu7Fy91U+yDwosMqgkp2dLeIJRUVFspkp9e5aW1slu2DA4/csKipCeXm5i7Lv8PAwenp6JGNnhskN84c//CEOHjyI+vp6UYJua2uTrieJ1gBcHtTe3l4cP34cRUVFaG1tlUCSnZ0t6sgZGRk4c+aM3Nc7LT55jwiVLF++3EWthM8AcbWBgQFEREQgPj4etbW1ePfdd2XtUxqfh9LikaNzSmVtHlT2ycvLQ1ZWFvr6+vDFF1+grKxMMkdlFcZrTzUc/l4ph0Y8W6vVigsatQ+Vqi/svPLahoeHIzk5WcQSmAlTxILqQOHh4bLG+Pk8h56eHhe5LU9PTxc16DuPuwLj48gasYfp6WmMjo6K2QnnWNndo/8G3bYKCgpkN4qLi8N9992HrKwsxMXFIT4+HrGxsYJHhYWF4fLly+j61uOTnhTMNjmCxMYK7fv+9Kc/4fTp0+IvsXTpUpjNZsTFxeHee++FVqtFUlIS/P398cUXX8DX1xdPPfUU1qxZg9WrVwMAzpw5IxhIf38/pqenJShs3rwZP/nJT+SacKDeZnM6hl29ehU+Pj6ivktVXDc3N5w7d04WCH1xU1NTcd999yEnJwdjY2MICwvDihUroNPpcPr0acTGxiI2Nha1tbXYvHkz9Ho9WlpaEBkZKYPkHNcjTYYUgqGhIfl8Ukqio6Ph6+sr3CyeO7vt7BT/JUL01NQUlixZgrGxMRgMBoSFhYljnsFgkKmHtrY2jI2NYfny5VhcXIS3t7cA6ixxqVZCfhqbDOxE+vv749KlSwgMDERjYyM6Ojrg7u6O0tJS/N3f/R0MBoMQbwEIm4Brr76+HhkZGejp6RG161/84hdITExETU0Nnn76aZSXl2NmZka8ddmh5MZOgQcaP83Pz4tCOOdr2Ul3OByCry5duhTl5eWCs953330iDc/GS2JiokyLbNy4EZcuXZImAisRag9WV1fj/vvvR1tbG06ePClq4hSSJb5J7Jmz1uRfxsbGwmAwiKzc2NgY7HY7li5dKtxA4qY+Pj5CG+I64jrgnC+v0djYmFyn6OhoBAcHy2gfG2bEJUlHMpvN8vcchRwaGvreWd27IuMjg59jQYzmPEhCpndFUVGRy++bmprkZjMN5y6dkJDko6q6AAAgAElEQVQAnU4nWno0ZAYgOxR3jYGBARQXF2Pfvn3Iz8/H119/jQsXLmBychLZ2dnYvHkzDh48iMHBQTQ1NWF2dhZnzpzBsmXL5NxpVM7MTZkp8py42ym7hl5eXjh16pSU0AzkzHIBICIiAh4eHlIKEAZYt26dy/WgxBHLo4SEBHh6esr8q8lkQllZGQoKCpCSkkIbPslSickBEAFP5SjQneUXBU451sd5UQqAHj16VO5pdHS0CJuybKGyNa8Lyzhmm0rogyU3oQKbzSYPMv1emTEo8VO+lu+TlJSEyspKeHp64uzZs/jxj38sJbiy8uA5xsTE4Pjx41i5cqXLaF58fDyGhobE4L6iokKqC6XMlfJcaYnInw0NDcm/WbKxnAcg9zo9PV2qF8C5OSYlJaG1tVXWHw8vLy9UVVXJ57N07O3tRUJCgvhY0+P25MmTCAkJQVJSEi5cuOCSmQK3Jb6IPXLkjOeiFMqYm5sTfJPXgeVvfHy8THxwTQEQYyyK43K9MCnhNVdKpIWGhrrocd4pTfZ/RIhUpVK5AbgEwLS4uJivUqmWAzgGIATAZQD/uLi4aFepVGoAHwG4H8AIgCcWFxe7/tp7sx2tvNA8mNrywZqdnUVNTQ06OzslENlsNsGBmKUxYNBmD3A2GA4ePIizZ88KXjIwMCCgb0xMDCorK6VhQEn09PR05OXlSclJ/h9nZIl5DQ8Po6OjA88884xklMqDGnD8nkzlCwsL5SaeO3dOKDGA8wYODQ2huLgYVqsVa9asQVhYmAg0ABANOJaVycnJ8PPzg1qtRkREBFpbW0Xpl6KNNpsNVVVVWLt2LUJDQ3H48GFh6be2tuLUqVNISUlBXFwcwsLCXGZ9lWU6j9bWVoSHh8NgMKC2tlYWbllZmUug4P1kgOF3MBgMiImJkdKTeCG7eSy/KHXODYWCnsTNqKbc29vrsp54DnyA9+7dC7XaOd/7xhtvCDZHpWmWibxWx48fFwVlJRZXUFCA2tpauTZ8f8DVLYyHVqsVXp5yPpuYorK8ZKNAq9XKa2j8xO4xIR7AFWIAnJtuRESEEPOHh4eRnZ2N+Ph4uLu749SpUy6zyhRcpbsbn0mOvLEZojQiovgq75FGo0FHR4c0DXlQg5ABkfO6RqNROKv0ztBqtbKZKa81J36UDTZ+X+LISvuGv9bc+J+IFDwPoFXx378G8M7i4mICgFEArNN+AmD025+/8+3r/upB3CY/P18GySkuyUVAeZ7h4WHU1tbCy8sLJ0+elItAz4Xs7GxZWMnJyVi7di2io6PFfDw9PV0Y/f7+/uJ/MTExgcbGRgFrBwYGxJ/g4MGDOHDgAMLCwpCSkoKkpCQJLNHR0cjJyUFycjLy8vKwZcsWeWj6+vrgcDhcvqdSBBSADInn5ORg69atMBqN4v/LTOXkyZPYt28fOjs7UVZWhr1798o88vj4OHQ6nWAogHOxrFmzRpoYzFZramoAOIU+161bh/HxcZw9e1YaP2+99ZbMq9bW1uKtt97CxYsXRXUGuJ058N5MTk5ibm7ORVyV8AA3H/6MDwfPUdnsYDNKrVbLGhgaGhLSsnKYvqmpCQkJCTCZTEhPT0d0dDRSU1Ph5+eHZcuWScecHUh+DjmCarVabDJramrw9ddfA4CsCdpehoSEICEhAfX19XjkkUfknLkmi4qKUFFRgQcffBBDQ0M4efIkHnzwQcloKNDKTI4BFYCoi/BgycpuKwB5+HlUVlZi2bJl8n2JybJpw0yW64rNIQYwqvLs2LEDp06dwscff4za2lrxpuAoJrl0NpvNZV3xPcfHx+UcldUB7yUAYTuQb0hbzomJCfT29oqMnNVqxdzcnFwzXn9WR9xkGWDJTSReT9yZ95ZCuTabTcyK/tLx38r4VCpVNIAfAvh3AP9L5Zyo3wCg6NuXfAjgdQAHAPx/3/4bAMoA/IdKpVIt/pWzoGfrlStXBAzmAmE0J4DLaN7Z2Ync3FwpkdRqtbhQkVpCfIjNjsHBQRQUFLj491Kws6qqCrW1teIhYTAYkJ+fjytXrsDf318aHlwIycnJGBkZEaVYni9l0Rk8lFkZvSOUADYbDSSWbt68Ge7u7qI2PTQ0JFmSh4eHNCj0ej3WrFkjEuiUlqc5zPDwsADHOp0OL730kpTUer0e8fHxYm351Vdf4ZFHHkFAQACOHDmC4uJipKSkoLy8HHv37kV6erosMApDArc10wICAkQynPQMpTer8iFXGgExsFPRmXQcjmexU07JdcBJhyC5OCAgAA0NDcjPz4fVasWbb76JLVu2yL1lpqAs03hYrVasW7cOxcXFkoXzu7D7SpXtY8eOScXBzj2z/Rs3bqCkpASpqanw8PCQNczPUJ4Lz4MNImVQVjb37r33Xul2Kv+exkXx8fGigE1TK8IfnF+m54uywaLT6bB7925UV1ejoqJCbCj5+cpuc2hoqHgSUxGHGRvvIwBRylHCIQkJCS7ZncFgcMmElVAPr6Myy+vs7JT3J06qhFl4vuycs8RVqoWTS/l9x3+31H0XwMsA6PobAmBscXGR6YwRANtgWgC9ALC4uOhQqVTj377+9jcHoFKpngbwNC8egxVlcLjQeHAXUuI9JFdyRyWtJSUlRTA2wKkfRuHPhoYGVFZWir8ou76FhYUICQmRwEUukYeHh5RBnONl295qtaKjowMAEB8fL8TOrKws7NmzR8bSHnzwQZGe4u7KmxQQECD6ekrqjFJ6/8iRIyKTHhAQINLs69evBwB0dHRg2bJleOyxx9DQ0CCLMCwsTPhsarUaRUVF4l9SXV0NnU6H1NRUvPbaaygvL0dBQQFycnJw8uRJhIaGYt++fTh69Cjy8vIEtwJuu82xI86AMTg4KMGKGZWyO6jMBgC4lC+cKmG2TnMarVYr0mOAE3Ok0Cy5e4QGXnjhBQCu6sv8XGZb5LRpNBq888472LVrF3Jzc4VMq1ar0djYiOLiYqSnp+Pxxx9HRkaGXHPiwawGAOdo5eOPPy6dYG7OStMhrlvSnbgBKDFVXo8bN264cB2tVquU+hERESgvLxfaE2kjSpoKy0VSWnp7e1FaWoqsrCxxQKMcvM1mE7P2gYEBtLa2Ijc3F/X19UIH4/Vk8sGmhb+/P3p7e5GUlCSdXqrtEM/k86G878oOtzIg6nQ66HQ6yRZJk+Ga43PD92JmqDwYtDUazf8exqdSqfIBDC4uLl5WqVTr/qvX/3ePxcXF3wL4LQAEBAQsEmjmF1ZyhQAI+RSAaOw1Nzfj+eefx8MPP+zy3qdOnUJraysMBgO++uorBAQESNbHMoqNj+joaMTExAgVBnAuWJ1OJ8HOYDAImB4TEyNOa+np6diyZYvgNnzILBYLHnnkEbGeZFBW8oq4M/n5+aGtrU2C352HTqfD/v37UVFRIYGagT80NBQRERFy80+cOCEZHwOfTqdDcnKytPbpMJeeno7Dhw9LZmGz2cS0KD09HRUVFSgvL5fs+OrVq7IjswxnlsBApLR85HUkyx74blmkvBbkudlsTl24yclJPPjgg+I0xsA0MTGBhoYGJCcno7CwUCwTOzs7RSSBn89gzKxCmQ00NTXhkUceEaNynivhlPr6ehw4cAB79uxBTEwMBgYGkJSUBJPJhKamJqGi/P3f/73oypE+FR4eLpAA/5trDnB1giM/UcndI7GbQZG4ns1mEzK7yWSSzWlwcBCPPPII9Hq9NC9o1WkymbB//36kpaXh4sWLqKmpQWVlpUBJwG38jSKrFItQVjjsuiqFKIir0Xie70dsk0pE1IRUNsjuxD55r1gtKIUhPD095RlTfo4ScuF1pXpQeHj4X9Xj++9gfA8BeEylUnXB2czYAGAfgECVSsXAGQ3A9O2/TQBiAODb3wfA2eT4qwcpHyaTSdruvEDcQanlxk7b4OAgDh48iIsXL4o6MYNETU2NmA7zIvM9rVYrIiIiYLfbERYWJlxB4DYfa+fOnYIf8gYxiHEyoqmpCUajEX5+foiLixNKA3fTvLw8pKamIiYmBsnJyWLdp8x+aKQDOEv+trY2tLW1oaurC1evXpVgTHFQPjzh4eECiBOUTkhIwK5du6Rco+jqkSNHUFJSAovFgqioKExOTuLw4cMYHx+X909NTYXJZJKmSU5ODpqamlBcXIyLFy+68PeUOzeDH4nUHR0d8lpKPQG3SzmlkxwDER9CDw8P+Pn5yXTK5OQkDh48KFju2rVrkZ+fj6KiIoyPj2Pv3r3o7e0VAVN/f38MDg7KNSK2xOyA55+RkYH9+/fDaDQiPT1d+ISDg4MyGXTgwAEx0eF5cvPTarVYt24dtm3bJswAduC1Wq0EYTYklB1e5YgdrwHXNK8NMyEK0gJw6cjTjzcvL0/IvU1NTdJwYMVks9nEHvXixYs4dOiQdJ2VWCVFTnn+zFL5jLGDSwIxAGl2KO8rs31Kjul0OpEYU6py81mmWZVyXbNLS/I9D6UtKMtaZvLMjgEItEF3wO87/suMb3Fx8V8B/CsAfJvxvbi4uPgjlUp1HMBmOIPhUwA+//ZPTnz733Xf/v7Pfw3fAyAKrUlJSYIlEKhUpvDsLikxpN7eXrzzzjvIzMyEl5cX8vLyxPIOgCicKMUDWBpzjKiyslI6Xp2dnSgoKJCJAOD2OJxWqxWCJgFlq9WK6upqyTr52Z9++imOHz+O//iP/3DphCp3u4CAAKSkpODgwYN444034Ofnh8TEROEtfvrpp2hqahKStlqtxpo1a1BZWSnObxzbYcap1+sFCH7ppZeg1+vx1ltv4amnnkJ1dTV2796NkpISAE57yK6uLnz88ce4cOGCXFN6qJLa88Ybb6CwsBBeXl4CHit334CAACkrw8PDBdRXYi7KbraSfc8AwU2qtrYWH330Ed59911UVFRIoE1JSRGJ+KqqKuj1eilp+PBbrVbJtuhCR69k4HaJdeDAARnVo7MZN4CwsDB0dHTgsccek+vBLJTnywYLP5PdWQDiIMeSOikpCTdu3EB6eroEo7m5OTF8N5lMohijPEcGFBq6M2tkQ4kdXWWQ4TXluFd2djYKCwtRVlYm7nTMyP39/V1wMbvdLlaOXFeZmZk4c+YMZmdnXbB05TPp7+8vQsBqtVrgiujoaCQnJ6O2tla+B/+O5SibE3eWvqy0SINRYnxcP/y3ssGhvG7KDfovHf870vOvwNno6IATw/v9tz//PYCQb3/+vwBs/6/eSK1WY/Xq1UhISEBxcbELIVkZZPj/wO02N3B76qKyshL/9m//hu3bt+ODDz7AqVOn8MknnwjOVVNT42IrmZycjIqKCgCQG2MymaTUsdvtsstzDpS8OOJZJAtfvHgR586dk+/0+OOPY8uWLaioqEBVVZVgjMpZTYLR6enp38EzLRaLBGzeSJbX7733HrZt2ya7fm5uLvLz86VJc/LkSVncZ86cQXx8PD799FMkJSVh165dAJwP6AsvvCBWiSwzQkJCoNfrBZvJz89HaGgoysvLpYxQUo+io6NdbD2Vs5S8t1zowG3JMe7YDJh2u9NwfefOnaisrIRerxcfVz8/P7S2tuLAgQM4efKkrIn4+Hg0NDQI9svPs9lsOHv2rAQEJRa0a9cubN++XQLYmTNnJBPnuXFUkMFGrVZLRgVAxid5Dzluxfdcvnw51q1bJw83H1RlxgPcnlgiXsZzoJ0ly8PU1FS5TqTyZGZmik+0kg8JOCGGtWvX4plnnsHevXvR0NDgsgYJGdyJtVqtVhHOoK0jsWkGPQYmZZMqNDRUNkPea61Wi8bGRsHoGPQYJHmteE6EMpQHnxVlY0N5DRlQlfaTfB2Fab/vUP0Xydj/kyM+Pn7xs88+w9DQEPR6PWprawFAAGGl0uqduB8vNH0GWIryZoWEhGD9+vVIT0+HXq9HTU0NcnJy0NDQIGB0Q0OD7HSkwQBwaZA4HA7o9XrBXZTNB+JmFosFer0eWVlZkrXx9w0NDTh48CCA25xElsMM9E1NTWhoaBC+4ubNm2EwGGR3pnptTk4OhoaGkJaWhnPnzqGyshLPPPMMfvjDHyImJgbvvfce4uLiYLFY8PDDD8tiJc2G5tlcSMXFxYL7vPPOOwAg+Fd+fr74e5AIzZlULkKWRgx6pBsQEuBDoszu+JAqvXpLSkrEy9ZoNGJ4eFiyEFKOeGzbtg2zs7MoLy8X6gUzqoCAAJESIy5msznJs7/97W9RWFjoQofgfacZVExMDOx2O6KiohAeHo7m5mZ4enoiPj4eOTk5aG5uljEtwDl1Qyw4JCREutj8fz6MvC5K2IVlMYMcg5iyU8nv0tTUhNTUVMFgm5ubZSNSXvOdO3ciKysLH3zwARobG6WM/0uYGAD5LOJ6SlGBdevWiS8LNy8GYSXBW3m+arVa7pnyvjOw3dmhVR78XGbzSrN6o9EoNC7l5wCuuCLXwLVr12AymVTfjTh3yeSGzeYUF5idnYVerxepGyVviNy6ubk5IacyK1Qaz4yMjAg3j+k/g9mqVauwdetWAE4FFA7HW61Wl7nagICA7+ADVPXlFEhpaSlmZ2exY8cOREVFAXAGNKPRiLa2Nrm5iYmJsptRPFG58Do6OrBjxw6Mj49L5sKATC4TydmdnZ3o7OxETU0NiouL8emnn8pieuutt4Qpv2/fPulOFxcXS8ZATbs7idUAXAzYAed4XU5ODtRqNXJzc7F+/XqhvUxOTsLPz0/uC+c+gduNCqrckKT9l7q7yimEiYkJNDc3Izk5GV999RUiIiLwyiuvyP1Szm5OTEygrKxMtBJJ3eHCZ3DlvSQeevToUTzyyCPfIRYPDQ1Bp9Oho6MDCQkJLsA9J0AAJ67KrjnBdgZ1Bs6RkRH5Odc2r4tyvSuvAzui7JYqVVOIjXFsb3BwUDIr5Yw7v9Pzzz+PlJQUlJaWSuXCtcYApMRdeRA+4vdiQNNqtS7TNnzulEGagY8lPmEdZdD6r4LencEYgExwAM4NMikpySWrBSAz5KxGCHdotVpcvnz5O+ucx12R8cXExCzu2bMHzc3NkrExi2C9v27dOpSXlwNwflkltYKpNeB0xeJRXV2Nuro6KR94k5h+h4WF4cyZM2htdfKyw8PDERISgsnJSQGu+eDx6OrqQlNTEx5//HH5WVtbG44fP46RkREZyaE8OEURAKC2tlYCBD9v586dqKmpEc6fv7+/SGmx1CUFAoA0J5SjcH19faiqqkJGRgaefvppaLVal+vwPzko+15fX4+DBw+6ZNMARCOQmJASn1ESsxmEGYwAuDwISqxT2TwiAZ0k7pdffhknT55ERUWFEFMZGGhEzbJJ2URg2UY4gkGag/BK1oDV6nS8KyoqwoULFwDcniwhxgRAFHuU3zMgIABr164VEQ2tVouRkRGXRsDw8LAQoknE59+yVD579qx8hvKzCeDzGnHzNZlMkoky0HOj+PDDD0XSiwEoIyMDVqvVZQQS+G6Dafny5S7XmGT/I0eOyOcrzb8ZULkpAc5GGZMKXmMmB0qoSrkWlNmj8tx4HjxsNpuQtCcnJ+W+ApD1mJycDK1Wi88//xwjIyN3b8ZHS0VmJsxITp06haqqKvj7++P99993GV/igud/czHs2rULu3fvBgA8/PDD36G68Oc8iJP8d4+4uLjvZEyJiYniT/B9R2lpqUuQIGCflpaGtLQ05OXlCcfuzsNisYixMuA6/ws4F5VGo5EB9bm5OZn75UH3tJqaGpcgsGbNGhQVFcnCpA5bR0cHioqKcOLECdTV1SEgIAC5ubkoLS0V4jK9EHgoy11lcGDw4HQGAfA7MwGqsbABZTQasXv3brzyyisoKirCj3/8Y8lGdDqdOIopgx//xw2IXLpDhw4hNTXVZaSJc9JnzpzBCy+8ILACpygAyLgYOWrUXvz6669lQ52cnMTw8DBu3LghmX10dLQoyJDjyQztTqxqcnIS8fHxsjHcSWwmgZgP9sTEhHRf+bp169YhOztbJi8AuNBIrFYrBgcHpRnBgKnM0ohxA5B7xFI7OTkZNTU13+m2Kru6ExMTiIqKcvm9cmKHAVq5TpSND+L4AFxKct4rrjHq8/EeKZViGJSVXeC/dNwVgY8HpxR442n6orwZypJHOe9IzKqhoQEffPCBiHR6eXmhvr5eBEhnZ2cRERGBpKQkYb0T3+LuGh4eLlp/7AoS+2K25XA48Oabb4oxUHp6OoxGoyz4sLAwAea7urqkHFMeShHQ7wt6AL6jCfjpp5+ioqJCrkVmZiZmZ2eFc9bb24uKigp8/PHHaG1tlV2WXLWCggLExMTgySefRHJysuCTwcHBKCgocJHz2bp1K86dO4cXX3wRtbW1SEpKkqCiBKQ5dsgAAdwGp3k/ifcplUoYVBgcKSpaV1cnr929ezfUajWeeeYZHDlyRO45OXhKLiKzS47hzc7O4ujRoygpKRFIhBsPsdBdu3ZJk4sQASGUpKQkEZ1YuXIlQkJCpPHB65CZmSnddOXGzLVEAJ/ZGvE24DYxl1kLHQEbGhqEwvTyyy9j79690Ol0qKmpEaK8Wq1GZmYmUlJSkJubK+R8m80mM+sMtFx7nJZgwLHZbELoXr58uQQV0kQGBwdRW1uLtWvXugReZdan0+lE7Zy/V2KgXHvKYKYUNgVuZ4QMZlyrygYMhxyGh4cRFRUlv2MTFIALZvp/RKTg/+bh7e0tQUJ5JCYmIjk5GQcOHEBDQ4OA/OTzMWtQ4kjMGH7605/K+zDzuXjxIrRaLaKiolyaD1u3bpXGBODcoaOiohAfHy9kYJKMGcg0Gg2effZZIV0DzuDlcDikOcL3V4oIKA/ueseOHZOfdXR0YHJyUhSSm5qa8Pzzz7tkb+TgWa1WURkpKnJODzLwGgwGkcqiAEB0dDTS09OxefNm6QDv3r0bhw4dkuCqDHptbW2ora3FwMCASyYdExMj3WbAmd0Roujt7ZWST3kQgyGgz44nMzXg9kQAx6iUpFabzclH/MlPfiLfmQo0gGvQS0pKQkxMDH70ox+5BBaNRgMPDw+o1Wrs27cPL774In75y1+itbUVqampYmxtNBpRVVWF4eFhrF69Wq69TqfDmjVrUFVVhdzcXBFvYAbKc7116xaio6Ph5eUlWZJSuUY5Qunp6SmbBx/shoYG+V6rV69GWVkZBgcHkZCQIDiWn58f1q1bJ9etqqoK9fX1EsjYQGGwIueTgZif5e/v7zLwz/tGPI/3ZnJyEqmpqWLrqISkmDDQp/hOgQieIzM7Prd2u11G7TjdosTwuDly7XDdEOYgb5BxQananJycjBs3buD7jrsi8AFOegWzHmWXlDsbbxRNeYDbOI0SKA4NDUVjYyO2b98uEuIszYDbYzcAsHLlShk/4o0qKyv7DqcKcKb0x48fB+DkuVHGHYAsfGKH7L5RZPNOPIP/7u3txQsvvOBSkhgMBikt+O+PP/4Yhw8fxrZt25CXl4cTJ04AAEpKSoRic/jwYbz88suSJXR2dmJ2dhbr16/Hb3/7W/j5+cFisYgoKcVRlVglu8+pqalC0AacfL9jx46hpKQE7777LvLz84XuwgdNSW9Q3htlmcPyhJkq6RLK68zsNDMzEzqdDpWVlQCAwsJCNDc34/e//z1iYmKQnZ0NPz+/7+CKer0ee/bsQWVlJdRqNd58801kZGRI5kn1mueffx7Hjx/Hli1b0NHRgWeffVbk+zUaDdauXYuAgADs2LED27dvx7Zt2yQTA5xjhMxCuEaVeFZycjKOHj0KtVotI2qdnZ0oKiqS7FitVotCCadhuIETvmCjzm63uwSUiIgIjIyMYOfOnXj//fcxOTkpmbCSMsXASloK1zaDHjcL3oOEhAS5VszsGNxyc3OFQ6lsLjIzYykL3J7JZpbH81ZmfoQzlGpK9HpWdvHZzOHGQXXxoaEhF+K3TqcTi4Lw8HAEBgbi+467IvDRRavrWymnqKgoXL16FSdOnMCTTz4JnU4nUkOAa+uaOIQSJAUgFntJSUnS2WKZy3IqLCxMjHWoAUelFavVirq6OqFuREdHS5bIbJLlNOBc7BkZGSgrKxMcAoDL4DcXiHI3pLk5AzNLKe68xOx27tyJoaEhHDhwQFyvDhw4AMBJtdm9e7fwEt955x2RRFd6fQQHB0tmR5yyra0N7777LkpKSrBq1Sq5FhkZGTAYDPjpT38qEvtqtRqlpaWoqamRzIVkWiWlQTmJwEwDuF3GsGOan58v1CX+fHBwEHNzc0hJSUFqaiq0Wi2GhoaEELtt2zZotVo899xzGBkZkWtJZRVqAGo0GuTk5KCoqEhI1l5eXtJo4mQG1wibHrOzs0hPTxdqT0lJCZKTk1FfXy+bDjXiGIj0er1k4Bzub2xsRFRUlIvYgM3mnGHm9eKh/G8O+HMN8DvSJoHD/L29vdi2bRvq6+ulicFzoOmRElpRluHcdJTKMUlJSRgZGYHNdlszkA0mSkzRp5rZ2MTEhEvgpLQbx/6Y4Sk9V/5SEsCNkLAFn6nly5fL6+g5Q1oX9QrJs+Xcvt1uF0MjWlr+peOuUGA+cODA68XFxYiLi8M333yDb775Bmq1Glu3bkVwcDA8PDzQ1dWFhYUF6TrygtjtdhezapvNqdy6uLiI8fFxPProo0hMTERcXBweeughrFq1ComJiUhISEBPTw9OnDiB6OhoPPbYY/Dz83OZJ6UK9LJly/Doo49KSg84Gwyjo6OIjY0V050lS5bg3nvvxZdffonS0lKYTCZERkbi+vXr3wFbQ0JCoNPp4HA4ZEg8NTUV7u7u+OUvfymSVj4+Pnj88cfR3d0t7lWAs3SLjIyEv78/lixZgvXr18Pb2xtzc3PQarXIzs7GhQsX4OHhAb1ej7/5m7+Rz7ZYLPj444/x5ZdfYs2aNdi0aRNiYmLEELu9vR0tLS148cUXYbFY4OPjgxs3biA6OhpWqxVpaWlobW3F6OgofHx8xP7Q09NT5NJ9fX1FD/2e344AACAASURBVM1mc6rq0plNp9NhaGgIFosFDz30kPDdgoKCEBwcjImJCWzcuBGfffYZDhw4gKqqKvzhD39AfX09ysrKcO7cOYyNjYnrl7u7OwIDA+Hu7o6CggLExcUhNjYWp0+fRmRkJNra2oTbVVJSgmeffRYffPABCgsLMTw8jICAAPz/zL17VJX3lf//Qi6HyvGcgFxUDkqAlnBsEIgGmFiwtWAXgbYWnKbqrES70mrWstEZE11NtNPEdHKbFVM70caO1K6q6YrGGTGuCnEiSMpBjeeIETThIMr9Llc5XOT3x+nePsdcvvP9/v7xs9assQYPz3mez7M/e7/3+/3eDz74IPHx8Tr4atu2bQQFBfHee++xefNmzp8/z/Xr1wkMDOTBBx+kpqaGW7dukZGRwde//nU+/vhjBgcHyc3NxeFw0N7ezsjIiDoYm0xe1+CFCxfS19enQ84nJiawWq309vbi8Xhob2+nr6+PkZERdu7cSW1tLY1/nwk8MjJCWFgYzc3N2qX929/+htvtpq2tzcfw02KxMDw8rBP45L3w9/cnICAAf39/zbomJyf57LPP1F18amqKyMhIQkJC9B0ICAjg6tWrZGdn09HRoSNEBwe9bscmk4kbN24wffp0AJ1BLFmwWMHLuyojQGfPns3o6Kg6r8sM5r6+Pg3UjzzyCA8++CAmk0kTA7PZjNlsZvr06cycOZNp06bh7+9PREQEIyMjzJo1i7/97W8888wz964D8+TkJA6Hg9LSUmw2mxKZ5cE4HA61IhLLqLu9yu5ekim98sorbNmyRbM4OXUcDgcREREkJSVpthkfH69j6aqrq4mIiNCMSU5k8ddLTEz0MRaYmJhQgPzFF19kx44dqmb4og6TlAr19fVERUWp6Fx870wmr640IiKCsrIytZRPSUlRIFjW0aNHtWQ1Equlkyk8toiICDZs2EBYWBhPPvmkQgpbt27VshZQ/S94s8ShoSFycnJwu91Kpo2IiFBLLindRG5o/LPgTMbnItjm4OCgZnySaUj27nQ6KSkp0UxZlCty8MjPSxYt+6GpqUnL3KysLHbu3MlLL70E3OnmT0xM8OSTT3LixAk+/PBDzW6ys7Opra0lPT0dgBUrVtDU1ERYWBgNDQ0cPnxYTQOKiooUcnnllVeIjo4mKChIJ40BPg0AWXdr0aUUNplMFBUVaQn92muv8fzzz2tnWg7dzs5OCgsLsdlslJaW6nMT+y9pfMhn3i35MnoCCp4mMzKM5XFTU5PaqMl4BpPJRFlZmcIwUqYK11ay0dHRUU0g7qaoiH+g7BPRF0vGJ9lfXFwckZGRpKenK3ZsxEPlHZHqz+jh19/fj9PpVCekL1r3ROATE0GjqFskQdLpraurw2azqTVTZ2cnGRkZ2pAw2tsYV0tLi1qGw53xiAL4Ctje3NzMY489pnN3U1NTtWyzWCx0dXUp8P1FBODS0lIFsKurq5k/fz5Lly5V+ZP8brgTRC0WC7/61a+Ijo7+XGMnLy9PQfW7eXt3r7uDqtHtZdmyZTpvNjc3lx07dqgDx7Zt26irqyMlJQWn04ndbmfGjBm4XC727dsHeHmLDoeDwcFBkpKSVBEiNv5SIgJKVREyrJRcRozH+BIIblRRUaFlLqCWV4KbyWcuWLBAsxr5LJPJxEsvvURGRga7d+/GZrOp1joxMVHhAOOSIdkej9ewVbztZHjPCy+8wK5du3zKvKqqKuLi4mhoaOCpp57ixRdfVOmcWGe9//77gHc/C5ZspF0Bul9FoC+BBdCDxe12K5YGd3TO3d3div8aS02Xy6VD0WfMmKHDto0C/hkzZig5+W56iVwP3JEgwh3epWRZss+ElmN0X5bnIcFQnrvgc9KElCUWcML1k2sUSpG8S+JsFBMTo38Gb2MwIiICm82m+6G/v1+xT4knX7buicAXGBioXnrgxTnS09Oprq5Wfo7YxIv6wWQyqQuKbD7JmoQTVF9fT1JSEhcvXuT555+nt7dXu752u10dKaQhcOLECX35ZWpaXl4evb29OJ1OLb1l9fb2alfXZrORl5fHO++8Q3l5Obt37+bUqVP6MGQTjY2NERMTo9/1i+yopAkhRFAZ7Dww4J09IoYDsiwWi0/HWmb+tra2sm7dOh577DE6Ojp49dVXOXbsGBMTE3R2drJu3To8Hg+pqamsW7eOy5cvk5CQ4EOzaW5u1kbGjBkzOHfunB4UYiArDh7gxT3F6VkmbcEdRw2jqD08PFzxV3kRRfJ18uRJvQbpLjc1NX2OJ2ixWPj5z3+uGYPdbmf58uU8//zzmM1mEhISWLVqld7nU6dOfW5q3vbt29UReN++faxfv17xQXnR5ODYuHEjP//5zxkY8M5BFicR8Dr7DAwM6MAk6UJ2dXWRkpKiwUAyHcliZf85nU527dql5HFhK0jQCA8PZ926dZSXl1NfX69jUQXXk7L97m6xBGan0/m5RoQEDVE8SMOlv79fg7Ixc7JarVy4cMGnE3x3M8UY6KUpKdm/xWIhKSlJZ1wDKqnr7u7WKmzu3LlKaZEExYgRSkUh/zsuLo64uDhtGgYGBn4lxndPBL5bt26pnAq8ZZR0FyWVFy87OcEEXDZuJuFgGblCAi7v2LFDvd3kxLRYLKxZs0aDHKAPT/S4R48eBbwnoXDdZIWFhWnp63a7KS4uBrzAubjCyCAeAdeNjYyCggKVnVksFp8Oa1dXFxs2bNCOodvtVqAdvBvq8OHDPsqQ1NRUdu3apVCBzCDJzMzUod3bt29n+/btREZGandYVkFBAcXFxZSWlpKdnU1AQIDyAOX0FE6kkcJhzDjFScT4HGRJBieZtNxrud/glRxGR0czf/58zVqCgoJobW3VkaDyWeDNPoQSAV5ThXPnzrFu3Try8vI4deqUdrzz8vKIi4vjhRde0Bf96aefZuPGjUrVAVSqJ2UZwOXLlwGvgcG6des4fPiwuoZLaSxUj0cffVSdbAANek1NTaogApRnaFScvPHGG3z/+98H7mR6g4ODxMfHk5OTQ0NDA/X19aoSGhoa0nt6t8JDeH4lJSVcuXJF77OUkkNDQxqwJDP71re+pcHKaBUF3oTE2FmWgVB1dXUkJSVpgJQ9IVxb4zjK+Ph4goKC1DZfurWS1ctMFckkIyIi9Bk7nU4te6XMlZ+Ra6yoqKC5uZnw8PCvNCm4JwKfv7+/au6MYmbwPsCCggLAG/QOHjxId7d3CrtgS7KMFApZ8vKdPXuWhoYGdRM2tuOFj2WxWAgICGBiYkJxtIKCAp3iVl5e7hOc5HeWlpaSkZHh89/MZjNdXV0+84CNpF2xDU9PT6esrAyLxaKuzWJSIDbxYrlVXFxMSkqK0jOKioqw2WwaAEVWJKVaQUEBdrudRYsWsWLFCu2AS6Ys5fuiRYsUwI6OjtYyV+55UVER4DU6HRoaUsqQNDLkmYliQe6tbEDBnCS7MD5jUSGIIsM4NxXulIqCl4kCQV5so59gYWEhjz32GLt27VIJ4NKlS5UDtn//fiIiIigpKVF6SG1trVr2b968mRUrVpCfn09GRgZlZWV6H55//nlMJpMGK5kFW1FRQUtLC/n5+bS0tKjrcXR0NGNjYyxYsECbNzExMUpkF9NS4x4FdH6J3A+hW8mhPjo6qhJLseQy8t1MJq+bixhSHDhwwIcE3NzcrL9bvo+UhcHBwTQ0NKiBrsyrraur83HAMQ5MEguynp4evVZjNiZyOSP+Zzys+/v7OX36NDExMT5zWiTRkUxOyn7pHMu+SEpKorm5mcuXLzM2NkZHRwcej1fb/FVy3HtCq5uYmDj11ltvkZqaqhs/OTlZu1mSossLU1dXx+nTp33shoytegHU7wZWTSYTa9euVS2fuDQHBQUpIVcCYXJysrbKvwpfMy7B1uS6S0pKqKiooL6+XrtbNpuNNWvWKF548OBBPfHFxBJ8h6yL0ajVavXxCrRarWRkZOgA7j179lBcXIzZbObUqVPKC/vJT37C2NgYP/nJTxgdHSUtLY2UlBR9+WXDyeAeafjMmTOHXbt26UsQGxtLa2srDQ0NnD59mu9///scPHiQqqoqBZglIMlGHRgYIC4uzkf4LiWvvChG6ZHH41FnbLfbrae7Ec6Qz1q1ahVFRUXExsbyzjvvaNADb2PH6XSyY8cOEhIScLlcahXv8Xj1nqtXr+a5555T2drKlSuxWq04HA6SkpLYtGkTJ0+eJCoqSikrRtqUvNxybbIksMXFxbFkyRJ9NhKoJYDJs5XAKGVoTEyMNvFMJpPOkamrq8PpdPpw8IRvJ2XxqlWruHHjho5+NHJSjQaxxmaCPBej0kMIxbLkswQfN2J5brebrKwsNRLp6elRB+WsrCzF68Fb1s6cOVOD4MWLF32+a3BwsNKJZE+kpqZy+fJl9X2UgyEpKUkPNcGxjRXVmTNnaGpqune1uiEhIaSnp2u2lpiYqLQVj8dDdna2dhclC+rs7NQsUTaMqBaMzHCjNtNqtXLy5EnloMEdGyrjJhZ8TIZl372GhoZ0Ywn20NXVxeOPP84777xDbW0tq1at8sEg5BqEVH3gwAF9CeAOZpWTk6OmoLIBZTaGWM9LME9NTWXRokU6qGfNmjUapCWwdnR0aBAT/E1mK6Snp+N2u9XWSpyMk5KS2LdvHxs3bgTuiL/37duHxWIhNzeX559/XrG66OhoGhoatNyUDrpkfALeG3EgsZCHO9md3CvpYG/btk0xQBmDaKQU5ebm8uc//5kzZ87oDF6RJr7zzjtkZGTgcDjIzs7GarWyatUq9uzZo5lURkYGCQkJvPvuu1RWVpKQkEB5eTlHjx7llVde4dVXX2XGjBmcOXMGk8mrrZYyXaARuCOXFNxOruXixYtqyy57VAKkmGFERUUpHCOHgsfj4fe//z1vvfUWPT09xMfHq+mA+OUZ5V6y11etWkVnZ6d+nmB2RkNYae7JwCmBecQcQbJyCY5ymEnpGh4eTkVFhcIcov8Fb8AX3mFSUhLf//739QCUeyA/KxWNx+PVhcv3keciWHxMTAzNzc3anJT7+OGHH+phZOyUi8zRZrP5+GPeve6JwAeo/lWwHiMjXIKGuLkaaRKSpRmBXLgzYQvuyGVMJhM9PT2UlJRo+Sz23pJNCJgdGRlJSUkJly9fVvmTdBqTk5NJTk7m6NGjehJt2LCByspKcnNzyc/PV189o0YyKCiIuro6dRuW7E6cnJOSknReAnjVCgICi+NLfHw83d3dGiglU5UNVVlZyeLFixUzEfOEo0ePajkjs2gLCws16DudTrUgMpvN9PT0UFdXpy7Cly9f1i7awIB3/q/MngB0tkRnZ6ceTPLcJFAb/fTgTsPjbguw/v5+Ojo6ePHFF2lubiYpKYnBwUHNwAcGvBPSZOSnlOfZ2dmkpaXR0tLCnj17cDgc6lIsmuuNGzfS399PRUUFy5Yt033zxBNPkJWVxdtvv61egPX19bz00ku88MILiiNL9it7ztgggDvyPTlYIyMjNeMXBoFkRzI3+O7V399PbW0tW7du5eWXX9Z9IvtdMmjJuATvKikp0UZJd3e3Nvvk8BFicWtrK/fffz/R0dFa+cjzkczxbm2tQE6SbY6OjioGL5Qtk8lrYSbPSIJaREQEo6OjDA4OavUinynNRekar1q1Sg8w6XADekhKpSeNI3nXJUuWrFHesy9b90Tgu3XrFq2trQqi19bWkpGRoS9GcHCwDh2XJVmB0+nUjEIyD2PQkyV1f3x8PNXV1Tz77LOfK2Fra2tZvnw5e/fupaqqiurqaoKCgnTMnnDY9u7dS21tLR0dHaxevZq8vDzNfmRmhZGvJoFXKANDQ0P88Y9/1M0ljrZz587VqWHykog55N1T5I4dO8bmzZvZunUr8fHxutFMJq+uWE7ampoa5QcuX76cCxcuqHY3OjqasrIyDayjo6NUVVWxePFixUpWrlyp5VhxcTF2u12pIOvXr6e4uFgbBcK36+/v9zGElKzA+FzubnwYuVzBwcE6UFxsqozltLH7C94Mc/369ZolHDlyBLPZzKZNmzCZvNpZ4bd9+OGHzJ07l4KCAhwOBydPnmTZsmXEx8drcwe8Aay1tZW8vDx+8YtfEB0dzZUrV7TiWLJkie638PBwDQCtra0q9bLb7ZSVlTEwMEBGRoYGS+HbiV+h0FqMa8OGDZw5c0az0PHxcS1VJaBJoHnzzTd1z5nNZm0IGu3A7Ha74moSaIxjP42WUnAHOpIyWDDN06dPExkZSVFREW63W5saUj2UlJQQGRmpjSjZD4JVi++kPHNp3gUHB2vnuaqqSqGCmJgYjhw54tPNlQFSUu2BN3EaHx9XCWdWVtZXZnz3hHLjd7/73b8+/PDDymhvbm4mOTlZVQnNzc309fWpFCkgIIDExETOnz/PrVu36O/vZ86cOXzyySdERkYqa15uljDGp0+fjr+/P2FhYZw4cYKhoSEiIyO5cuWKCvpbW1sJCAigoqKCqakpTCYTw8PD1NbWcuvWLSwWC6tWreJ73/se3/zmN8nMzKSmpobz589z4cIFrFYrNpuNqqoq2traaGlpYfr06Xg8Hh3fCCixeMeOHSxevFhP6vb2dnJzczGZTJSUlPDXv/5VZ8yaTCYyMjLo6OjgN7/5DXv37uWjjz5i3rx5OJ1OJicn+eijjwgICCA/P5+AgACSk5O5du0azc3NHDp0iMnJSQIDA2lqauLcuXOYTF6VRUBAAL/73e8oLCwEvFrQrq4uVXL09fXxyCOPsHjxYoaGhpg9ezbNzc1MTExw6dIl+vr6CAkJ8en6jYyMMDw8rJwtyfj8/f0xmUyMjIwQHx9PX18fcCcrXrBgAZcvX+axxx6jrq4Ot9tNT08Pt27dAryH3vnz53nggQe4du0agYGBFBUVMXv2bHbt2sUTTzzBxYsXqaurIzg4mAceeICZM2eyePFi+vr6tMH1s5/9jP379/P666/zy1/+kuvXrxMWFsbw8DCDg4P09vbyz//8z/z+979n6dKlREdHExERwWeffUZvb6+OC73vvvsYHBwkICCA+fPnExwczJUrVxgeHiY5Odln5Ka/vz+PPPIItbW1tLe3MzY2xuzZs/Hz81MjheHhYTZv3qxzYUtKSrh+/Tqtra00Nzcza9Ys7r//fkJCQkhNTaWvr4+Ghgb8/f2ZOXOm/juPx6tqCQ0NJSAggOvXrzM5OcnExIQqNmJiYoiKimLmzJmEhYVx/fp1Zs+ezcTEBJGRkfT19ZGRkUFzczM1NTVYrVby8/N58MEH+d73vofVamViYkJVSPfddx/R0dFMTEyQlpaGxWLhzJkz3L59m1mzZjF79mxlY7hcLvr6+mhsbCQsLIzJyUkuXbrErVu3iIiI4MqVK7hcLoW92tvbGRgYoK+vTzmicq3Tpk0jNDSUvr4+QkNDVT66ZcuWe1e5MTU1RXNzs2YD6enpSh25mz4SFhamBOK0tDQfXpQw28UmR8piKYflhDB2deXUO3funKoeFi9erP9eAGWTySvJSUlJ4dy5cwwMDLB06VIaGxuprq7mySefZNeuXZqm9/T0+HTtjCW8dLtSUlI4fPgw5eXlxMfHU1RUpKTlsLAwPbmN2l+ZswGoa0dDQwOrVq0iPT2duro6SkpKKC4uVncQI5dOAu/OnTupq6vDarWyceNGKioquHr1qkrS5HevX7+egIAALTPhjtGkdLuDg4PVrtwI/htLDeNcC2MH0lgSy/Pv7+9nfHycxx9/nNTUVPr7+xkaGtKsqKioSLG/1atXs2fPHqqqqigvL+fEiRMcPHiQU6dOERMTo58t3Vw5VATqKCgoYOvWrUo9Etxo/fr1PmWo0+lU7C4oKEjVDB6PRwcHSYkrdBCpAkQ3ayz15V6ITZSxqWW1WqmvryctLQ2bzaZUKMFHlyxZQlVVlTYixKVbmi9i/iBZttVqVY6b2+32saaSLrw0ksSKSq5brkkywmeffRa3283x48f1sDZyPRMSEpRsfPcoAlFlyeAmUVlI9dHQ0KCmw06nU3E7+Z7S4JRrNxo9yJ6T7rq871+27onANzQ0pJ1Jm832OW+6uxsM8oIWFhaqtA3umDbCHRqElE9GMqg0Ufbt26ddQOHsyXWAt2wdHR1l5syZ2tk7ePAgK1euJDc3l5qaGnbv3o3VaqW1tRWPx6PEVSkVZcmGls3mdrvZuXOnXm9RUREZGRkqI9u7d6+K9C9evOjTye3u7ubEiRPk5+f7OGUUFxfT1dVFRkaGBkqRvQl+IrZT9fX1qg7YsWMHL7/8ss893rBhA0NDQ5SXl6tyRrh7DodDeWoFBQVaKhvNReWlM3IZjffeCEXcPUDK2Awx0iOkcWBUtZw4cYJjx47R2tpKZWUleXl5artuNOqUIeXyfJcuXaqT8BISEpR2Is/CaK5gt9tpampSTXZhYSFnzpzxeb4SlK9cuaIHckpKik9JLi+wkNiFEmK0eII7IxYliK5cuZJnnnmGjIwM6uvrOXz4sNqlScNL3JONXV4JtHIfjK7lEkAlOMkIBrlOeX7h4eFkZWXpvZDDoLa2lhs3btDT08Po6Ojnylh5F8TYICUlRTl3g4ODNDU1MTg4qBCJUFw8Hg8lJSU+owrkvghJG3znUkunPz09neDgYFJSUigtLf1KOss9UeoeOnToXw8dOkR6erqPrfTZs2f58MMPSUlJ8fn58PBwLl68qA/N7XZraWv0CvP39/chgQJa7gIqzt64cSNXr15l8eLFXL58mU8//VQZ4x0dHfT19TE5OUlTUxMFBQWkpqYya9Ys/vrXv3LixAna2tqUlS6npwi+5eV/5JFHMJlMxMbG0tXVRUVFBY8//jjnzp0jMTGRtWvXEhYWxowZM2hsbOQ///M/mT9/PiMjI4p3fOMb32DVqlUsX76cv/zlL9x3331MmzZNRy7W1NRw8+ZNfvjDH+JwONi8eTO3bt1SML22tlYDVlZWFjU1NbS1tTE2NsbMmTO5cuUKn332GV//+tc5evQoDQ0NlJWVcfXqVTUEkBdt+vTpxMbGkpqaykcffURgYCBTU1P09fUp3CBCeCGZBwQE+LDpjURmEbr7+fkpfrNhwwZt/BizkEuXLnH27FnMZjOlpaV88sknavRQU1Oj2KwEy/b2djo6Opg7dy6zZ88mOzubkZERxsbGuHTpkiotFi5ciMvlIiQkhPr6eoKDg7n//vs5ffo0oaGhjI+PMz4+rj9jt9vp6+ujra1NGxUPPfQQs2fPZv78+fT19dHV1UVAQAAdHR1MTk4SGhpKbW0tISEhWtaKk/Xw8DCTk5MEBATQ3t7OZ599xuDgID/+8Y8ZGxvj8uXLdHR0qJX+8PCwVhjNzc3cunWL4eFhwGu51t/fj7+/P5GRkcyaNYuwsDDmz5+vZhBSvcybN4958+bxjW98g5CQEJKSkliwYAFZWVmKhTY3N9PY2KiQxdWrVwkMDKStrY2YmBj8/f2xWq3MmjULf39/RkZGiI2Npb29nZiYGCwWC9evXyc5ORl/f386OzsZGRmhubmZsLAwXn75ZRwOBzdv3lSnlZGREcX2Jycn9eCQgBgQEKDGJfKdhEsqh/ovf/nLe7fUlUHaRvmWDF2OiIj4nI06+E5AMwLfgJYhIg0TntrdTQ9jN/iVV14BUGBaJrHJKdnU1MSqVavYvHkzAJs2bSIrK4vXX3+duro6srKycLlc2hHs7Oz0IWIL/cHISautreW99977XLfz8OHDpKWlqYnB66+/roTq1tZWXn/9dS5evMi6devo6Ohg48aNPvfu3LlzZGdns3//fmw2m1r2iynp+++/r27J0pB44YUX1AMP7tAG7Ha7D8/R6XTS0tKCw+Ggu7ubjIwMNQ8VCVt/f7+Pg25nZydxcXFYrVYtj41L7N6NXeCWlhacTqfCGJK5STlqtVrZvXu36lclSxCSt9g4HT9+XLvrAwMDKoXbv38/5eXlrF+/nubmZm1sFBQU6FDxZcuW8ec//1kzTuOYRdlPYhAqh9Pq1auxWCxKJr/bTNW4pMsqzQP57nL/AW1yxcXFUVpaqjw2I8cuISFBy2qBGIzmBlIteDwe8vPzmTFjBvX19dTW1pKWlqaNM1FLiRWYy+XiyJEj+gztdrtCDkJolopFMrGuri5tMAhRXrh2d8tShQkA3hEQHo9HbfGN90HUJtLUkQTD2ECU797d3U1FRYVyJb9s3RME5oULF06dP38egF27dukYRtkoOTk5nxObGx2Ujx49SnFxsc/mMra7jS6/snElnXc4HMyfP5/33nvvC3WzgM64ld9XWVmp5bDoZ4W3dvr0aS5evKjegSaTiY0bN35O8QHeIGaxWHy6yzLGElB9rlBIbDbb565xaGiI6upq7bTK5urq6lJC6fz58/F4PErpSEpK8sHTDh8+TExMjJJFhee1efNm1q9fT3BwsGYZ4KUAGQnfYt0vQcnoBiIdceFtyWhNuNPMkP8vJZpgQAKCi0onOjpaXanT09NxuVw8/PDDnD17lj179vD0009js9m0CSEHks1mw2az8fOf/5x3331XDVyFSrFy5UrKy8txOp3qVG0yeU1Mly1bpriS0Kmk45mSkqIUoNTUVHJyciguLqaiokKzuPHxcerr61VyJ/dCVB5S/j388MM6QVA613Kf8vPzsVgs7Nu3T8v94OBgnE4nS5Ysob+/n7KyMt3TcAefAzQJkHdC5tMIfirPV+bgCl4mz0JgI8HqBF6SREOwuMDAQObOnavyUSO0I2MZZPKdkI7FzEJwX8nwBQs3luwydVF0vUYsU/5epu7V1tZy/fp1xsfH710CM3jF40888YSPnY2QLY1BT4KQuKQMDQ2xfPlyKioqcLvdPPzww1y8eFGDnuBFkskZjREdDgfLli0D4Be/+AVr1qxhcHCQnJwcNdsUZxaxo4fPj2KU7qgRTDW234UicPXqVXWgEKKwBD1xYJFO3x9KuQAAIABJREFUrHHV1NQwMDCAw+FQ2yQBqOvq6vB4vC42omVMT09nw4YN7N27lyVLltDV1aXDYgR7EpwuPT3dh48lcjUxGV27dq2P1dXdq7e3l+PHj+vJK2WtBL36+nq9LxI0ZHNLQ8TYBDFmv0I0F36gmB9s2rTJR1sLsHXrVp599lnKy8sZGBhQ+6SKigpefvlldu3axbvvvqsdSHGEEQJ3XFwcDoeDzs5O6uvrfQLHwMAAgYGB6lwiOJYoY4QEXFpa6mMDBeiLvXTpUqxWK1lZWRw/ftynEWQymZg7d65msoIrm0xewX1VVRUrVqzg7bff5plnnmFoaEg1ukLcl0aJHEB3c/KMhhFut5u0tDTS09PVFkxoTlIVSXCX5ykOQkb6mIwYsNvtGpCl0SNc1KioKIUNmpublY9nVOTAHYK/2MiLIasRvxfJpdFoQa5PEo3a2lq1yL97GJZx3ROBr7e3V7tR4M0EEhIS6Ozs5NChQz4/KwoO6exK4IiOjubw4cOfIzaCN0MRoqm4VoSHh1NTU+NDoLRYLDpO0mazERAQoIOL5syZw7lz53C5XDQ1NVFXV0dhYaGC/RkZGVoOGZ1DoqOj9VolW5szZw5r16710cTezSkUdcixY8d8NrTValVqi9lsJikp6UsD05NPPqlefbt27fI5QIxjMx977DGys7MJDg5WyEFcZ7q6uli/fr2e7kFBQdTX1zN37lzlauXn53P8+HEFsoVcLkC7kUAeGRmpFvHSgJEDSdQAX7SMFkMdHR00NjbqUHXwHlxz5sz50nuxYcMGAJ03IbyzK1eu4HQ6yc7O1qzIaE4gzQfR0Pb392tWZlTXyF4TPFKuV6zURSo4OjrKt771LQCff2/UnIuW1m63Ex8fT0dHhx6egI8hx+nTp1myZAkPPPAAV65c8Zk4Z2wiud1ulUGKnZiRaC28QzkAJGDKmFdjI0a+a3h4uNp6NTU1aRIhWLLxO4k0UQKUcfCT2WzWezQ0NERTU5PP4SMD4+U7Gfm9ubm5fPjhh8CdJplkzNOmTfvCvQD3SHPjhRde+Ffh5sgw7+vXrxMbG0thYeHnGNhiOS2SoJCQEBITE5WCIkvmTISEhDA8POwDrF+9elUbDlNTU3g8Hvr6+rh58yYffPCBypM++eQTli1bRmtrK35+fuTm5qqAOj4+niVLlpCens74+DjNzc2YzWY+/fRTBZ4XLlzItGnTuHnzpjrFAvzgBz/4ynsSFBRESEgIMTExJCYmEhERQWJiItOnT2dycpLExES+9rWvfSU7fe/evYSGhvLxxx9z+/Ztbt26xRtvvKGD2Z955hkqKyv505/+RExMDG1tbZSUlDA0NERGRgZRUVF88skn2O12Zs2axapVq8jLy+PatWvqtHvp0iUiIiKYmJhgYGCAkJAQBgcH8ff3JyQkRNUN4gIsEEVfX592DcfGxpg+fbo2kaamppg1axajo6Pcvn2byclJFi1axHe/+1327t3Lb37zG27fvq0lMYCfnx/Xrl3TQ+/o0aN88MEH/PGPf+Ts2bN8+9vf5vXXX1cb+8LCQh0unp6erhw5uV6bzcYPfvAD/vKXvyi/rq+vj7CwMGw2G35+fiQnJ2O322lvb6etrU35c+A95OQaAwICWLp0qWbnixcv5qOPPlI35Pnz5zMxMcHY2Bj9/f1qlOHn56eNi9HRUZ17UlpaitlspqGhgdDQUL75zW8qjDE5OUl4eDi//OUv+Zd/+ReVSNrtdtxuN35+fvpc+vr68PPzY9asWYA3UZg3bx5Wq5Xk5GS9DuF5BgYGMn36dLWmDwsLY2BggJGREUJCQmj8+xCuhoYGbXZ1dXVx5coVEhISaG9v1/fR4/HQ29vLxMQE4+PjOh0tMjKS69ev655qb29XXq7wDgcGBvDz88Nms5GSksLHH3/MwMCAcnVjY2NxuVx0dXWxbdu2e7e5ATB37lzmzp2rA8SXLVv2lSWW2Wz+3H+XcYNGEq0RCJbUWpoXxtNDyh5AM7Gamhoef/xxGhsbtZQzmbzOvpIx1dTUqNZRXD5ycnLUjXlsbExB6erqamWVj42NERYWRmVlJadPn/aZH2E2m5k/fz4RERFkZGRo+SuqAAGs5fvJySnUlubmZjZs2EBQUBAlJSU6E9diseiYzF27dunsgm9/+9uaEXd2dlJVVaUZkoi/ZRkzOdFIilOLDFiyWq0+QnnjbFfjoCjw4o11dXVamo2NjVFUVKSaW8lIzGaz6qDBm0EYIQez2UxiYqJmuDJuUb4HwJtvvqnPRDrbNpuNhIQEfZ779+/nxRdfBLwmrFarVb9PSkqKGisILlldXY3FYiEzM1ObbJGRkZoZicxNnr3cB5PJpLhnVVWVTnmTfyO8vfDwcHWR6enpUes2wQq7u7s1kwOUFC/vRmJiItXV1YyNjbF9+3bKy8s1M2pqatLnILihNKjAe7AHBgbS0tKiOKDguCKllExQMkr5P6OLjjRCjFmxXIPsV1lyb2SAleB9Mo9XsmBpEDY3N5OSkuJDe5H7+FXrnmhuJCYmTl29evUL/5toT8H7shopGTKKUVJgAVSF/Ah3Jm8JLwng7bff5ic/+YkPxmLsQsbFxfHtb3/bx55dVmNjI4cPH/YZwi1/J+WbuL8MDAyQm5urQK3L5fLhJ4mLrOhljS+yWNk7nU7GxsZ0sLV0WgXIFrxlYGCA8vJydaWZP38+7777LmlpaWzevJnt27eTnZ2t33fp0qVcvXoVt9tNSkoKDQ0NdHV1sXPnTgDF006cOKEvm2REFotFJ8jJKi0tJT4+ngsXLii+IyWQBDUjpiPEcfk+AliLHlTGT4rJ6bp166iuriYrK0sNIdavXw+gA6IE0mhoaNDBS1/UVFq/fj3vvfceS5cuVWy1p6eHkydPUllZqXhuZWWlln1yQArEEBUVRXh4uOJ64eHhCvrHxcXR09Oj08DAWzIL/mWxWHA4HNpMkaAg83mNexdQrW1hYSHPPfcc27dv5xe/+IXu13Xr1ul9FB5pamqqQiwTExM88MADmvXJM5QOvuxHgRw6OzvJzs5WUvL4+LhOMJMyXFgJxsaDlLZz587l5MmTPjipscNqbHJ9EclY8Pi0tDTlQYoDuLgnGQ982X+Cr8o0uIqKCm7dunXvNjdu3rzJ/v37KSgoULkaeF868AaW2NhY1qxZw6FDh+jo6KC2tlaNFKXr5/F43YSNfm3SDRWQ+fLly8yfP9/npnk8Hh9dYk9PD08++SSnTp3SOQ3gBdBXrlxJUVERDQ0NVFRUaHfX7XYrDnfhwgVMJpOWGaIWycrKUpzvblNTWfJdm5ubKSkpwWQyaReuqqqK8fFxzR4EE5HvYbfbyc7O1msWO6DKykoNrnl5eQwNDdHY2KhAsJzQERERrF69mrfeeovs7GwOHTqkjSS3201LSwtmsxmr1aqEUyE3r1y5kuLiYrUFkixEMCwJYEbTBnE5GRgY4Le//S07d+6kqqoK8ILcZrMZj8fDzJkzqa6upqqqiv7+fux2Ozt27FBjCRmXKc7acpAJzrZr1y4fJr8R7xRGgNvt5ujRo7zwwgtqU1VXV8e6devo7u6mrKxMg7hxVKnRcBS8wco4D0bmeUglYzR1SE1N1U6x6LXl38i+lAPA4/Gwbds2JfzKYSE/GxER4aNuKCsr02mAAwMDrFy5kpiYGKqqqjQIjY+P4/F4jQSkqZebm6sVirxfgYGBpKSkKFFdOuIPP/ywKnoEg5Mh7FVVVUr1ETMLOZzGxsY0O5MKRrBEj8dDbm4uBQUFWjXJc8vOztZnamx8SJkse0XI8sYZ0XevewLj+4//+I9/HRsbIzk5mfDwcN577z0ViH/961/nk08+4Y033uD69evMmzePkJAQli9fzne+8x36+/t56qmnWLx4MY888gh2u52PPvoIs9msYyslwMyePZuYmBjldoWEhBAaGkpHRwf+/v5YLBZGRkZ44403sFqtPPDAA7S2tvLHP/6Ro0ePaord19enk7OSkpI4e/YsbW1tSlgVmsfixYsJCQnh008/xWQy8eCDD3Lt2jXuu+8+5dHdvWQW6H333ce3vvUtFi1aREpKCjk5OcyfP5/c3FzmzZsHoFiNn5+fTq0Sc9MTJ07gcrloa2vj008/xW63s2fPHj799FMGBweZnJzUKW2XLl1i2bJlvPHGGxQWFnL58mWmTZvG6dOndah7YmIis2bN4oc//CF+fn40NjbyySef8D//8z9Mnz6d5ORkQkNDdQPKhp6YmOD69eukpKTQ3t6u8ivBw4Sg2tfXx1tvvcWf/vQnlixZon6MfX19LFu2jNLSUl566SUCAwP5xje+QXFxMT09PURGRup0OsHMZGKXzWYjKiqKhx56iPb2drWXr6mp4eLFi7z//vuEhYXxwx/+kFdeeYUrV66Qm5tLdXU1//RP/8Qf/vAHXC4Xy5cv58MPP6SgoID4+HjFK51Op2ZBMtJQgHg/Pz8SExPV71C05oIJWiwW/vu//5vQ0FAmJyeJjY3FarUqzmmxWJicnGTatGm43W6uX7+uhOyamhpee+01xeumT59OQ0MDjX/3gZRA8fHHH3Pt2jUlWQcEBLBo0SKdwStT70QKGhkZSUVFBdOnT1cNcV9fH4sXLyYxMZGAgABaWlq4evUqycnJ3L59m/DwcK5cuUJHR4dO3Gtra+OBBx4gIiKCxsZGH7VOZmYmYWFhimHLEHSZNJeWlkZCQgJHjx6lpaWFxYsXs2jRImbPnk1eXh6zZ8/WKWpyGDmdTp0mJ3pu4Zbe01rd8PBwXn/9dR16LJFdZlosXrzYpww8d+6cTyOjtLSU8vJyLXXF085YysbHx7Nv3z4yMjIAlJcm+J60/gsKCoiOjubRRx9l9erVJCUl6chC8M5nkNmhYkjQ1NRES0uLT4s+Li5Or9mIRUrGJzQIo3YY7nSiLRYLcXFxPoONJBMWs1PpQIIXjykrK9PGS0REhBKNhQydnp7OypUrNQOTUv3999+nrKyMNWvWYDKZdJiOUF/k50pKSpSnKBnc6OgoGRkZpKamatAXWZ3ZbNayVSzsAc3IjKTXpqYm9uzZw9q1a32yW6vVSlVVFWvXruX06dOsXr2akpIS1q5dq6YVYr0ls2KTkpLweDwkJydTU1Oj/Mbq6mrsdrsC5EJBKSoq4urVq0q1ePbZZwE0K9y6dStJSUnqtL1hwwbeeecd9STcs2cPLS0tbN26lfLyci3jBwcHGR8fV7xPuHBCvZKZv+CFETo7OzXLDQwM1L0gUEd1dTU7duzg1VdfVWxPBttLBiSZu5S13d3dmq0LBBEeHq5uJnBH/tXR0aEUI7fbjd1uJzw8XM1uhfYj8E1tba1aqYk0saWlRbXDMgRJ+HeAzk2ROckyQkLm5WZlZfHuu+/qnhc3oKysLAICAnRujggCxsbGtHQODAz08R38Khjvngh8gL5ccirLjQev5fnBgwf1Z42B5IswHPByvSQ4DgwM8O6777Jy5UoAJVIa+UBjY2Okpqby4osv+gwKX7x4sbpDDA0NER8fj81mo6GhgfT0dAX64Q7lIjg4mNWrV3/pdxWrKOk8yVQuY4CV3yeUGwGEo6OjycvLo7a2Vvl5cj+ysrLUXEDoD4WFhcqcd7vdPP/882RnZ5OamsqcOXPYv3+/T4nodDpZvny5Yjjr1q1Ti3Eji142rjRrAgIClB8oAdCInRpF8+B92QTUtlqtXLt2DfDqZG/cuKHqm+DgYFXxSFdU7MgAXC4XOTk5iv2ePn2aGzducPDgQfUglD1w6NAh3nrrLZ5//nmKiopYu3YtLpeLCxcuUFJSovZWUiKtWLFCIQqxT29oaGDv3r2Mjo7qiIKioiJ2797N7t27yc3NxW63U1VVpVpbownDgQMH6OzsVFdx4b5JNeHxeDQjk2AB6OS/RYsW0dnZyTPPPENxcbEqboxEX2Njr7u724c83tLSQlBQEOPj4zqrRExkjR5/KSkpGqAkyNlsNg1sgMr3UlJSaGpqUk3y0NAQx44dIzMzE7PZzJkzZxR+OnLkiI+fX3x8PHFxcZSXlyvUtGTJEv3ecmAL3cvhcFBRUUFSUpIesMbS/dvf/jYXLlz4P87cuCeaGwsXLpyS7lt2dvYXjm+8exlHLkqKLy698pAFB8zJySE+Pp4///nPipcYjUzB+yK+8847PProo9rtBW+GJzy+u1dvby+lpaUcOXJEu2zy2TLIp6amBqfTqVIjwWeMChLhFXZ3d3Pw4EEfFYNkqKJBBIiNjVVaSGVlpZ5+EryE2A2ouaooT7Zv305GRoYqL8RlQ07aoaEhCgsLGRgY4NVXXwU+3w0Hb5aWm5vLu+++S21tLcuWLSMnJ4cjR44AqGmB4DfyUslnWa1WBceNlBzhuIn4XZxOMjMzSUpKIjs7m66uLp3na/yzqGikG75v3z51GjZOtpMhN4cPH8blcrFjxw6efPJJtanv6upi1apVuN1uamtrcblcGkxSUlIoKioiICCAmpoadb9ZvXo1sbGxHD16lIqKCvLz89XRGu44LhtHJkhgc7lc3H///XR3d/PEE0/orA8hBYu5qgyMGhwcxOl0sm3bNnbu3KlmA6JCAVRrLtmRONzIwCFRTsizEFxWnkFDQ4PeOyEoy6AfkXJKBiuVluiIpdKQz545cyY9PT36b3Jycli/fj3h4eHMmTOH3t5enSRoVHmImceRI0cU05RrFWxacFfBq6Ojo/VQ/K//+i96e3vv3eYGeLV6dy/JjMbGxjTrsdlsLFq0SB2OhZ1vnL/Z1dXF0NCQyps2bNjAsmXLtMtmLAski/nggw/41re+5UOUNZlMvPLKK+Tn5+vnGt0vYmJitLQEX4mdLHFrBq9Erbu7W7lZ8qBF+5mens6zzz7rY7MvmQHcoZIInUCWjMo0zuetq6tTdwwpd3Jycqirq1MT1omJCS3H9+7dS0NDA1arlX379vHaa68pLUfUAULnkAygtLSUhIQEzp49qyoGmf4m2YtkZ9HR0T5EX5EXiXJAMuzMzEyOHz+u303ggJycHF599VX1OkxLSyMiIoK8vDz279+vxNi6ujodASABbsmSJapuET2njGY8efIk586dY9OmTTovIj8/nyNHjmhTIj093Wf+q5FKJPdjz549mM1mVqxYoWa2Yq4he834vCQDl+loQuyW525svpWUlBAdHc2CBQuorq5m48aNOJ1OysvLeemllyguLsbpdPL000+TnJzMuXPn1EVFXFUsFov+nQxDkvJbfld0dDTj4+NcvHhR7eDFEVy+c1FRETExMZSUlGhVIUHcaIRhfB9E43vjxg2sVitbtmwhPDxcM0R5Z1wuFw6Hg/r6erKzs1m0aBGnT59WmZyY0sqgLrgzsFyqQ1kCM3zZuicCX3d3N+vXryciIkJxG6F/hIeHa6YjJVllZSXHjx/XMjUrK0vLNDmBe3p6yMnJoaioiE2bNmkH1Gw2KxYn+MDFixfJy8vTU12CoayGhgZWr16tD0sClQQhEcFLU0OyNKPHH3jLeclMpMso2E1LSwtHjhzR0gLulCxSOhqXWOaLRlgmusXFxWkn1mKxUFBQoNhIUFCQBhWj1hm8mYy8+BJAjR3Z6Ohojhw5QlNTk3LYoqKiOHbsGB6Ph7KyMlWv2Gw2H76hyI3Ad6h6eHg4DzzwgJJvReUgulHwBsiXXnqJzZs389RTT/Hmm2/S39/P2bNnefjhhzXTkZkkdrtdA6EMcHrrrbdYsWIFGRkZmn1Lx3PHjh3Mnz+f9PR01TcvXbqUsrIynQ4nMke5JjF2EKhDnr/ZbMbhcCiNKC8vj3PnznHw4EHy8/N57rnntCss2Y8M+hZRv91u1wwJvJVNd3e3qjJENidBS3TE27ZtIy4ujhMnTvhYmLW0tGjmJhPi5PnJPA1Ay09pxhQWFtLQ0EB5ebkGsv7+ft566y0KCgpYt26dZsSCYxpL82XLlqlnoFhsSbYv+zkuLs5HsVRRUUF1dTX5+fnq0hQVFUV0dDSrV6/WKslisajTeVpamtKEhIcrldc9r9woLi7+16eeekrLFHFjHR4eZnR0VDuQFouFS5cu8cgjj7BixQoiIyM5f/48brebv/71r5w9e5b4+HimTZvG7du3aWtr4ze/+Q3/9m//RnBwsHZ9pPsnGr8f//jHnD9/npCQEEZGRhQbAZSJXlBQwPnz57l+/bqm0uIeK07FkZGRhISEEBERoQJ2Wfv372fatGlqBiA8MCFmikXP7du3aWxspLGxkVu3bukgIavVqqz0hQsX8tFHH+lnS3lrs9lYvHixuklPmzYNk8lEe3u7utbW1tYyMjLC3/72Nzo6Orh58yZDQ0MMDAywevVq7r//flpaWkhPT+fKlSt85zvfob6+no8++ohTp05x8eJF/uu//kvvVUtLC5OTk2pvZbfb+eyzz7h06RImk9fVIzQ0FEBdg7u7u5XJHxYWxtTUFCMjI0yfPh273c6VK1cYHx9nYmICh8PBxx9/TG9vL48//jhVVVV0d3fT29urM0FaWlrIyckhJCSEhIQE3nvvPebMmcO8efNob28nJCSE2bNn097ezvLly4mLi2PTpk3aQZZDTJymv/e97/HBBx/Q19eHxWKhra0Nk8lEaGioWkkFBATw6aefcvv2bVWpnD17VnEli8XCzZs36evrY8OGDZw9e5bjx4+TmJjIyMiI4rNBQUHqOvK1r30Ni8WiFlbS2Q0JCVGcOSwsTINsQEAAw8PDPP7443z66accPHgQt9vNZ599xuTkJIODg9y+fZv777+fWbNmcfv2bX23Fi1axA9+8APOnj1LQEAAwcHBDA8P86Mf/YjOzk4+++wzpk+fzq1bt+js7GR4eJg5c+YwMDCgaork5GRiY2N1D4NXQdPQ0EBNTQ2AOkBLwNq+fTsDAwNcv36dBQsW6B6uqamhrKyMsLAwfvzjH+Nyubh586Z2er/zne/oaAqBk0JDQ2lrayM0NJTR0VG+/vWvc/HiRXp6epicnKSjo4Nnn332C7u690Tg2717978mJSXpRhMgefbs2fzoRz/ioYceIjExkW9+85ukp6czY8YMxQVkxqyI0gUrbGho4E9/+hNbt27VdH54eJioqCjGx8cJCQmhqqqK7OxsGhoaCAkJYcaMGUxOTuqmE8+2yclJPv30Ux555BFsNhtLly5l3rx5qts1jvCLioriV7/6lc9ps3fvXlpbW1mxYgWAYi3y57KyMlJSUoiNjSU3N5d/+Id/ICsri4ceeojk5GQiIiL4xje+oQO+L126RHx8PO3t7dy8eVM5bJOTk7S2tvKrX/2K999/H5vNhsPhYGRkBIfDwYcffsiPf/xjRkZGeOyxx7hx4waLFy/mt7/9rWpCq6urOXPmDIWFhTrh6/r167jdbv7whz/w8MMP43A4WLVqFf7+/uoQ3NzczMKFCwkJCdGXenh4mIiICPr6+qirq6Orq4uJiQlCQ0Pp7e1VjEY6oNIN7+rq4vbt2/j5+dHR0cHPfvYzduzYgclk4t///d9ZsGABdXV1TExMqDzQ5XLx05/+lL1792K1WrUBs3TpUs3E8/LyqKysxGw2ExERQUBAAA6Hg76+Pm7dukVoaCgNDQ384z/+I3V1dXR3dzMxMUFQUJBKpqqrq9WNefr06eoCEhERwbx58xR28ff3Z3Jykvb2dsrKypg9ezYFBQX88z//Mzt37qSwsJCDBw8yOTmpzixyeJjNZqVMAbS1tREbG8uNGzdob29ncHCQRx99FIfDQUhICPHx8ZSXl6tnovggDg8P87WvfU29DsfGxpg1axZjY2O0tbXh5+fHxMSE0pq6u7vVy9DtdquscObMmUxMTBAWFqaUmIULF9LY2MiNGzcAL6sgODiY27dvk5iYyK1bt0hLS8Pf35/ly5eTkZFBbGwsH330kXIH5fBfv349f/3rX5mYmKC/v58PPviAqakpWlpaGBkZISwsjMHBQaXUzJ49G39/f+Lj44mNjdW9Pzo6yvvvv8+DDz6olKsvC3z3RKk7bdo0LT1kiQSpsbFRO26CWQneItZE/f39HDt2jN7eXt566y3GxsbYsWMH4JVEyQDszs5OBc1fe+01Nm3apOmz0ErgDpNdpDIigztw4ABr167VrrOUz+DrxuJ0On1K3C/6bsY/392ZFmmWWDYJW91ms5GTk+PDyO/s7MTlcilWlpeXh8Ph0OHRg4ODqnCRblxFRQUlJSVs27YN8IrAT58+rWTo1atXc/XqVaqqqmhoaKC+vh6r1aoDZrq7u3nsscfUJ3HTpk06WEeUG3FxcYyOjmK327Ukk5LXKIETFYi4EgcHB2uZZzKZqKio4MKFC7z//vv86Ec/ori4mG3btvHaa6/hdrs5cOAANpuNjIwM1q5di9PpZO3atVy4cIHBwUFOnjxJWloaS5cupaamRjuLpaWldHZ2atPEZPLaQwUFBdHb20tVVZWC+iLlE1lZf3+/egXm5uYSHx+veG1+fj4REREcOXJEh3NbLBYt2b773e/y0ksvYbPZ+OMf/0hBQQEXLlzw8foTwrrsS0DJz9KcsFqtSv+SfSkzgkWyFRcXp2wF456WMlmUQy6XSyWL0hyQ5yGEdZnuJ5ZlBw8eVAkeoHssJyeH1NRUsrOzdfyrfDfBQ8XhJTExkRMnTmjGLhih4ITi+wfebq5QvGQ1Nzfz3HPPYbfblVolDT7ju/lF638V+Pz8/O4D/gB8E5gC1gJXgb8AsUAj8I9TU1N9fn5+fsCbQB4wAjwxNTV14as+/26GdWtrKxUVFQwODtLR0UFMTIxqA8HLUZPZmZcvX6anp0cdRMLDw0lISGDOnDk0NjayatUqXn75ZcUzxDFFpqSJ84RxyQYBfGgYbrdbAeLw8HBltsuSzVVeXq56T9m8xoHVwvYvKiryaXxI59jonPJlS8pAoeykp6erBCkjI0ONWhsbG7VrLKVQVlaVxepPAAAgAElEQVQWbrebOXPm8M4775CUlKQDqsW6PS8vj8zMTP7zP/+Tn/70pxw4cIDa2lqloBw9epScnByOHj2q+t/t27czNjamgQvg7NmzhIeH6wxXwXk8Hg/Xrl1T0rU8Fxk4bewCBgUFsW/fPrZs2cLOnTt58cUXWbBgAePj47z22mvKSysuLuapp57iww8/ZGhoSDHjgYEBTp06pTrVrKwsnn76ad58800OHDhAeHg4hYWFdHV1kZmZicPhwGq16jxdaT5UVVWRkJCgL2ZkZCTl5eW4XC6fqWLV1dU8/fTTNDc3U1xcTGdnJ4cPHyY6Opr8/Hyd2nbo0CEGBga01BZcVvAyoVsJziqHMHhpX3IPREkh5WZtba3OaZEOtzRTZB9Lt1waX0lJSVpCy7OIioryOSzj4+O1CSUKCfCqVaKiogAoKyvjwIEDKiMcGBjwkc9VVFTo3Fyx/hf+KKAJhXSExcIMvIEuLi4Ol8uF2+1Wu7iysjLFh+Pi4qitraWhoYHbt29/6fvzv6Kz+Pn57QfOTE1N/cHPzy8ImA78Euidmpp62c/PbysQOjU1tcXPzy8P2IA38KUDb05NTaV/1ecvXLhw6pVXXtFhI4BuBKMURVrq8kKYzWb1fBNBfExMDMeOHWPr1q0KrGdlZeHxeDQreu+99/jRj36kp6LIhuBO8DISiaUslWaBnMplZWU0NzdruWa1Wnn66adVMtbb26tyr+rqal5++WUqKys5cuSIdqHtdjtZWVnMmTOHq1evKvEWvLhHcnIyvb29OpBoYMA7XvJuG6vW1lYiIyMJCAhg//79Sgvau3evguLCwZOOr/G7L1++nMrKSurq6ujv76egoEANCqqqqnTEpDQH5JRds2YNHo+H4uJi3njjDXp7e3n11Vfp7OxUEwMhNUsDSjr18qLLpi8qKiIoKAiXy/WFrsUbN27kyJEjBAYGKm0iOjpaCcy7du2ipaWFGzduaCdR9s7Y2Bjr1q3jt7/9rWYxGRkZOqhbuvQiiRPts+xHaYwtW7aMiIgI9fMTY02hdMhQHyFNl5aWKuheUVFBeno6mZmZqm0+efIkW7ZsobS0lIqKCqKjo8nOzlYXaPmsmTNnqpmDcP5ycnI4fPiwNsu2b9+uzR/wHuAbN27Urr+Rv1pbW6ta3Llz56qDtmjAxSpLmnmyh6SKCAwMJCoqihkzZujnSyAcGhqiqqpKB2iJm3NzczO5ubnk5OSot6QsaXjU1tayZcsWZUZIUH/uuefIyMjQYVHCF5WZNICPlZW8d6Ojo/9vdBY/Pz8rkAU8ATA1NTUGjPn5+f0AWPL3H9sPnAa2AD8A/jTljagOPz+/+/z8/GZPTU21fdnvaG1tVUJuXV2duuhmZmYC6GklKbNIoiSNBpQvJB2oGzduqIZX5umazWYdFiSCbHnJS0pKfIKfLI/H4zMbQpxupbtmtAgHNOi1trbqpklPTycnJ0cNF5xOJ/v27SM1NRWXy6UZgzj0rl27FpPJpKYCixYtYvny5Vy9epUDBw5QWloKeFv5MTExuFwu5Xc9+eST2Gw2YmNj2bVrF11dXTpXV05dwTx37txJZmYmeXl5nDhxQieXZWdnExERQX5+PmazmSeffJLt27dr2QbezCYpKUmt3nNycrRDmpWVxXPPPafZndzTu/WZRpPYOXPmqC5VluhSpYu5e/duysvLGRoa4tChQ8q5O3r0qAYSGZp06tQp7XZHRETQ1NTEb3/7Wz18JDN//vnnOXfuHLW1tZrpCC8wNzdXDy2Px+uaIkT6lStX6p9F6mUymdSjUXBXITFLmSiO0k8//TROp5OkpCQ9oLds2aJaZfl90ilNS0tT+ofY+Nvtdh/reIvFwpo1a5S7Z2QpAJpZS+UiDipDQ0NKvRGamBxaxsFP8s5JOSmlqQxMj4iI0NJZOsqHDx9WRczGjRtZs2aNdmRFViZyPxk+5Ha7Ff6Rbvfg4CAOh4P+/n6ioqJISUkhPj6esbExkpKSKC8vV1ccwXi/av1vSt37gS6g2M/PbwHwMfA0EGUIZu1A1N//HA00Gf5989//7ksDn7+/v3YS161bp2Xq4cOHuXDhgsqd5ASUaV9ikyNC8ODgYPbt28f27dvJzMzkpz/9qY4LBDh48CDf//739XNEthMdHc3777/P448/rpnM6dOn9UWXBy5k3IKCAh9ellEat337dt0YotcF74vodDo5cOAAGzduZMOGDZw4cUKlPfKSpKen8/bbb+NwODhy5AjNzc24XC4effRREhMTP2fBD/hMT5N17tw5Jfi+++67+mKCl7qSlZVFTEwMS5cuVTxUyh95+YyEXxHBy6kuJe+6devUQFS+b29vrzZHJDuX+2Q0iRUIwVjCGTPEpqYmn8MoMjJSjSOSkpJ0oJLMm+ju7tZyWxxURkdHcblcCm+8/vrr6qxjMpnYu3cv8Hkc9u4lh86RI0cUNkhNTSUoKEjhj8LCQurr6zXAlJWVsXLlSiwWC4cPH8ZsNhMdHa3mtYD6OMoskzVr1nD58mWf393f38/mzZtxu90+s2AkuMn0N1Gx/PnPf1YDiPj4eOrr64mJiaGgoIDS0lKqqqoIDAzUecei5hDai6h05HdbrVbFP4VXGRQUpBmX0fXHYrFQX1+P3W7n5MmTar4gFvk/+9nPdD/V1tYqiVosyUQdIis4OFhpbZGRkdTV1enUQbvdTkpKilYg4mAtLtlCP/qi9X8sdf38/BYCDuCRqampaj8/vzeBAWDD1NTUfYaf65uamgr18/M7Drw8NTVV+fe/PwVsmZqaOn/X5/4M+BlAUFDQQxIs5CSRkXWycYwsfbvdTmxsLK+//rparXs8Xpv6AwcOKL9NTpTMzEw2bNjAjh07OHPmDICqAuRGbdmyhccee0zLnbS0NHWHMC6TyTtDY3R0lLKyMh+XWTnZnU4n+fn5iq3Y7XYyMjIUiwJvYBILIZE11dXVUVVVRVRUFEFBQfow9+3bp9piOYGLioqIj48nMTGR/fv3U1dXR2dnp1oWyaYV9r+QOcPDwykqKsJisXDy5El1HZYyura2ltzcXA2Ua9as4de//rX+XoEYxBLeqKuUJb6BJSUlVFRU+LgCSwkr+J7c06CgIJ2XINctjjoC6Hd3d6tjjGSvNTU1vPzyyzqQSezNBLgvLy9XBYA4yhhlaf9/1t1cyP+bJVmmy+Wio6OD1atXY7PZNKhVV1f7lG45OTls3ryZtWvXkpmZ6TPDVxxxAHVE7urqUsNeuf+FhYW88cYb2O12xsbGtJyWd8FokwW+nMv8/HzOnDmjFC2bzaYY9dWrVykpKdGAJuW0NMckQ21oaNADMjo62seHsbu7W9UZCQkJ/P73v6erq4tf//rXCmMZubXyXQV2EvxZiOwAly9fZnBw8P9ZudEMNE9NTVX//X8fBrYCHVLC+vn5zQbEM7wFiDH8e9vf/85nTU1NvQ28DWA2m6eMeI5geRJ4BLRPSkoiNzdXN1tubi7Hjh3D6XRit9vVhUVuhpSZy5cv59y5c2zcuJGxsTFNvSXomUwmfv1rb9dbbpxYSxmXlNkyeEb+ThoYJpN3UHVWVpam/B0dHXR1dfHMM8+Qn5/Ptm3b1CJdXH/ffPNNoqOjyc3NJTMzUz+rpKSEwcFBNm7cSGlpKXa7nfnz56uVvFgyiZBbNrzxWq1WK3PnzlWcqb+/n6VLl3Lq1CkaGhrIzMzE5XJx8uRJPXCklE5PT6e4uJjx8XHq6uoU2M/JyVGjSCELyyYUAnN1dbVPkJRSUrIGwYY6Ozu5du0aKSkpGhyNtk4ic5O1e/duXnvtNSWHd3V1+ei4ExMT6e3t1UAu84GF2S/mloIp2Ww2zTo8Hg9Lly5l//79FBYWYjabqaysxOl0Kl1KvPv6+/uJjIxUyZboR5uamliyZIlipaOjoyxZskSf3+DgIHFxcar5ln3qcrm0vBRVjhH/lKx537597NixQzHH8PBwnE6nBrkLFy6wZMkSHA4Ho6OjmM1m/bcul4sVK1b4DPqWhgHgM+fCeOAYvQTFuDYnJwebzca5c+fo6upSiah0uEUDDHeGvst4BznQjdpiuYb/j7l3D6u6Ttf/X8iCteSoCwERUESUwERACdgRmCZObbFM/KbSltEOX/Uat/a9Kp2m07httqV52E7mobHR1Ky0NDQTxwOOB1ATFQJBQc6CHBYuZCGHBb8/2M8zMN+Z/fv99+tzXV3OGAHr8/m83+/nue/7uW+BkWTkTQTcEigkG6AUCy0tLezZs4eGhgYCAgLUHaeysvJ/FDD/v258PT09tQ4ODpUODg6hPT09RcAUoOC//0kH1vz3n4f/+z/5HviNg4PDfnrJjfv/E74H6AcQbC83N5e4uDhmzZqlL6aA8UKRC0YjM5LQ69+Xm5tLamqqsppFRUVcvnyZjIwMCgoKCAwM1GzYqqoqrToEfO+rPu/7u8lDkYXY1x1GNj8p3cWYMjk5Gegd2UlJSWHTpk3MnTsXk8mkqVzp6emkp6drKyW4XUBAAGlpafpzJPTnu+++Y/bs2dq+yCYk42TSksolVZaMJMnki9yn0tJS6urqFC7w8fFRNlRamdjYWIxGI1evXiU2NparV6/i4+OjEMCDBw90rEpYXJHeHDlyhM7OTt3kJGsB0M1Y2k5xJhH4YsmSJSxYsOAfVlVirySgfkpKCsePH6ejo0PNDPrmZ/T1wes7PpeYmMjMmTNVNhUb28vDyXxuZGQkCQkJLF26lBs3brBv3z6dckhMTOwHVYgLyZEjR5RAaWhoUOOLjRs30tDQwGOPPaYB3OLoIuoFmaxwd3ensrJSq98hQ4awY8cOXnnlFZYsWcJHH31EY2OjylLknsk7KViXVILOzs5UVlZSV1eHp6cn9fX1uLu7q8mprIOGhgZ10RFGVeaq7927R2pqqvowZmVlUVlZqSy+l5eXTvbIwbdt2zZNbhNCZtKkSWzZsgWr1apyFUDzlKXoEPyzL/7Xd0xO/l4+szwDDw8PoqKiKC8v/6d7zv9XVjeSXjmLM1AKLAAGAF8Dw4FyeuUsTf8tZ/kj8Ct65SwL/r7N/ftr0KBBPVu3biU5OVmrNmkjhNHct28fYWFh3L59myVLlnDkyBHOnDmjThKSurV//37mzJlDU1MTJSUlxMTEKMgvUoazZ88q9td3o/v222+ZP39+v5Q2ublySSrZxYsXVRMIf3OVFY2UJD3duXOHYcOGERISolbnVquVwsJC3NzcePDggQLycokjS1JSEmazmcuXL5OVlUVUVFQ/zFJcPSScZfjw4aojy87O5vjx41oZ+Pr6UldXp96FUqkJuyqSipCQEBYtWkRYWJjKBgQ6iIqKIjMzU+Uc/v7+ahclmIunpycHDhwAUAZcft/4+HiSkpL+4UZWVlbGnj17NJrTaDTy4osv8sorr1BUVMTvf/97bde/+eYbNm/erDbkVquViIgIZsyYoUE8jY2NWtlItdeXPBHBtvzOUhnm5ORQWlqqo1uiiauvr+/nniPvmVyCFTo7O6vHnLhxy6FYWVmp2caenp7MmzdPcTFArc0EA5SKSSocicFcunRpv4NSXJEFMhBDi5ycHP27lpYWddkRuEU0olarVRlegOvXr6sEysfHR78mODhYNzB532XaqqSkhKqqKmWDxaG7urqauro6fQ9feuklRo0axRtvvKGsroykSkEjm3ZlZaVWq/7+/gQGBvaLL+2rcxTFgnR7LS0tnD59moaGhn/Y6v4i3FkCAwN7vvzySw0d7uvSIBbd8LdZTsnEqKmp4ejRo7zyyissXrxYWztxwlizZo2C4Tt27ODAgQNMnz4dQDcuQKsNYaKExpfU+L6ygmXLlgEovic/U268TDE4OTnp9+vL0MkDS05OVrYVehfnzp07Wb58eT/L9B07dugJe/DgQRYsWAD8rZWVBSpGDtOnT1cdlSwgMWvdu3dvP5OBqKgoPv30U4UKRPwaHh5Odna2MoVWq5Xc3FyVskj4jgh2+9oG9b1kw5bMiYqKCj0sJG7wnXfe4dNPP1U4Q+5/cHCwZtLKve/o6GDt2rU6c1taWqp6yHv37rFv3z51Cem7qEUbJ3hXRkaG/r1YrA8fPrzfAVRWVqYbHvQKaK9evcqDBw+YN28en376qdpyiS+jHA4HDhxg1apVKkSX6lF+ptxjqeSkoxFThYcPH5Kbm9svGU0cfWSzFJnTli1bmDRpkto9ySEtB7yYaAwfPlwJpb73Qy5p4cUXUAiOvgSivLu3b98mKiqKtLQ0lYmVlJTg7u6ua/Tq1as8+eSTANpRpKamqnpDwuClSpYDUgoHwf6GDBlCYGAgiYmJfPTRR3R0dGghIUYKgBosCBQFvT6TdXV1v1x3lpaWFrUzEuwHetlKsUGSk7asrIzLly+r95l8yL5WTyaTiYULF3Ly5EkNgLl48SILFizQU6hvvKHcPDFQvH37trqN/L1AWVpCoF9bERwcTHR0NHV1ddpOwN/yQ/sGYwMqnzEajSxbtgyz2czrr7+ug/4bN25k4cKF/dhGuRcZGRna3sbHx1NaWkpkZKQuGBlhOnjwIO+88w719fVs2bIFX19fNTNwd3cnIiKCUaNG6eadkZGhg+z19fXk5ORw/PhxoH/2Sd+rq6tLs2yrqqo4cuQIUVFRREZGsm/fPh577DFycnI0elIOpXv37jFr1iw2btyobbO0kIDmLEi+slwisO7rMbdmzRqWLFlCQUEBSUlJ/Ra0TDcIYylfI0xsR0cHM2bM0IyR2bNnM2vWLKZPn64CYHHI8fT0ZNq0ady+fVuJsb4dg5hTREVFsXr1at3k3dzcePLJJzl9+rRqBuXdEzNcwRytVitxcXGKIUPvpiQtr5hyyvOQv+tLFEmbP2vWLA4ePMj9+/cVZpDOR1p0Z2dnxQfhb9WX4HDiUCOOLkKAJCUlqeegvIsy4QPoJIW8W6IrFZmPHCryvauqqtRpRcgKIfScnJzYuXOnOsoEBgbi5OSkba84scj3lf2j73vz99cvYuPr6uoiODiYpKQkVbu/+eabGAwGgoKCqKmpYf/+/Xz//fcUFhaybt06jh49ysOHD1WXJ9iSjN3MnTu3n5OH0WgkJyeHzz//nKioKLKzszWesG/SFMB7771Henq6Yh19LwmV+fscVNms5FQXvBJ6cZP4+HjVDkobIWLazZs3s2rVKqKjowkPD1d85MiRI1oFxsbG6uYvL5xUwgJAi+monKQ5OTnk5ORw+vRpbbUleNzZ2Zlz586pM05VVZVOYPz9tX//fnJycsjMzFTvM39/f4KDg7l06VK/+xIVFUVFRQVr1qwhJyeH69evq+JfFmVhYaG+4PJ5RZAsbZtU/X2vL7/8UitZHx8fSktLeffdd9m6dStZWVmsWLGCzz//nDNnzhAcHKyH3ooVK5g+fToXL14kNTWVTZs2KXMpG7JsWpWVlfzHf/wHmZmZ+Pj4aOLd3weY79q1i507d+Lj44O7uzujRo1i69atzJs3r1+lJrrAzMxMKisriYqKIi4uTmGEWbNm6eYirbGQLn3zeSV2VQ7i+vp6Tp48qUFS4rgth6kEDsHfNsPIyEjVJIqrjTDC0mK2t/e6P5eWlirZJO+TTHiIrVZWVhaenp64ublRWFiIk5OTOiPJdJUEUOXk5OimJy14ZGSk4pBidCBkY3h4uG5gFRUVhISEYLVa+60p6Qg8PHqDxZ2dndX4wNfXV/N2/9H1i2h1hwwZ0jNhwgT8/f37hWz/8MMPbN26VZkyo9HImTNn+OCDD5g3bx6rV6/uB9ZmZmbi6enJ8ePHmTFjRj9a3sfHhyeeeIJLly6pR5xUDXKzhWETScCBAweURZLNSkai5MSW7y2bUH19PZ6enmpBVVpaSkdHhwL+27ZtIygoSDdyEaKK1U5wcLBKbu7du0dYWFg/t9zFixfrZMfq1au5dOmSvrTbt29XZk3wkzlz5lBUVMQ333yjjPA/uhYvXqx4ytq1a1WSIJGMsgClwpbxQLkPgmMBqq0SaYp8/b1795TtW7dunU54pKWlqc2YtFmStCVC8ZaWFg2KEkPU8PBwUlNTef7550lMTOTq1au89tprakAqUh6Z4JDpk3feeUc1ktIaxcfH88orr+hY4dmzZ9VlOjw8nD179vDiiy9y9epVkpOTVVAuUQJyrVu3jurqaqZPn86UKVOoqanRd7qjo4Pbt28TEhKCs7Mz169fJzExkfv372trLgf32bNnFcsSYkogEmmnvb291cdSWP6+l0yafPrpp/p+S4srEyr3799nxowZfP7553qfRUYjz0M6HanOJApV7ql8L8Euhc2WiQqZihk/fjyNjY2K+clESt/fp6GhAScnJ31n5M++Ux59CTDBA43G3lAkYdw9PT25ceMGd+/e/eVifIMGDerpa955+/Ztli9fDvTql4YNG8bly5c5ePCg6r0+/PBDsrOztTWUzM0NGzawcuXKfho8aZ8F2PX19dW2R5xp5SR1cnKis7OTN998k7ffflvbWuhtYcaPH8+lS5eUKRXcQ05FqR77ZqsuX76cOXPmcO7cOXbu3KmbpHyd4COyyc2bN49Vq1YRFhbGk08+qTbg7e3t5OTkqLax76KbMWMGAAsWLPinm1tNTQ0dHR3qRB0XF6emnSKLEXZWDEmjoqJUCd/XiXj69OlqACB5wlIhHD9+nJUrVwL0az+ERS8oKCA1NRXonYBYu3YtdXV1SsBI9d5XR5adnU1SUpJW1NHR0bi7u7No0SKWLVum1VR0dLQyqLm5uaSkpCgo7uXlRUFBAdevX9f36N133yU3N1c31YaGBi5evNiv9W5sbFSxbHZ2ts7ZCqabmppKZWUl4eHhXLt2TYmhq1ev6qKUuERpH+/fv6/QRd/WVsKL5Ov6Vo6S2Szi32vXrhEcHKyORHLPAT1wxNBBDve+7Z9U1FFRUXh7e6toXwg9cbgRPaxsrIJlCjMum4+sBzkcS0pKdOpCsDrBIWVzE3OLvnPJjz32GNevXyc2Nlahj0uXLumBKvpM+b5SvMjBLdrZEydO0Nzc/Mvd+Mxmc09MTIwCv3IDxbpbNpdFixb1E58uXrxY8wLkYSQnJ/Ppp58qyyU3RmInRSgp4l1pMcTWWoiOkJAQUlJSeP3111UjJGaVMlMsv5sMkQuwnJyczBtvvEFLSwsbN27Ul1omFfq20DIX2lfiMWTIEBYuXKijPXFxcRQWFqom8R9VGn2vsrIysrKyVDN19uxZjcsMCAggNDSUrq4uNm7cyPLly5k/fz7V1dXEx8crgbFs2TL27t2rJ7AQQbGxsSQnJ/P666+TmppKTk6OGrQKXGE0Gtm6dauykTJTKi/mN998o3PIr732mmYky1SAOIjI/bx+/TqvvvpqP+3XX//6V5ydnf8vUqWrq0sNMsPDw3n77bdZtGgRe/fu1YopNzeXjIwMZSzHjx/P22+/za5du3Tzl+5BnnlSUhItLS2UlJTg5ubGiRMnqK6u5ssvv+TXv/41ixYtUtFwdHS0dgqlpaW88sordHV18fbbb6vMKTc3l8LCwn5uK+LILORT341PGNHS0lIOHDig1Zq8Q6+//jrQmzUjG9z9+/dV2/anP/1JibrHHnsMQI0F3N3dFbOTSkwO7b7xjyL3ks1TqmGJrDSZTBoUJkJsqTILCgrU5FYu0UbKupR/J/iqOGV7enqSnZ2tFbi8I2IJJ0WHOMyI7OzWrVs8ePDgH258/1zh9//DJZue3HRpAeXDffTRR4wcOVJHrNauXcvx48fZtWsX06ZNY+fOnQqWz5s3T29EcHAwiYmJOpsr9L6wyG5ublraG41GDVF5++239SHfv39fcQvZpOTrpbQWvCoyMpIFCxaQnp6up5n8TAHspY0T7AtQQSqgs4di2bRmzRqt5EJDQ9m/fz+XL1+mqamJc+fOsWvXLmbMmKEh2+np6YwaNYqMjAwePnzIwoULOXHiBN7e3ty4caMfZrV9+3a2b98OoACyaB0lREZsmVJTUzl48CDTp09Xu6JPP/1U8dE5c+ZotT1kyBCmTp3Kn/70JwCtIFavXk1wcDCzZ8/mzJkz/d4BWbQyyjZq1CgMBoNqweTezZw5k1dffZWVK1cybdo04uLimDZtGv/6r/+qrLiYAhw4cIC0tDSSk5P5+eefuX37NgsXLmTBggW4u7srTnn8+HGOHz9OUlISy5cvVxG5jIdBL74qGRBr167lP/7jP/RwDQwM5NKlS2zatInMzEzdYPfv38+9e/f0WUuEwqhRo1TyU1dXp7Onr7/+ej/JiGw44qDyzjvvYDT2jg/KBIc89w0bNvQj3aqqqjR1Tp5BaWkpnZ2d2pKKXk+CnaTKCggIUGYVUDxPYI+qqiqFfR48eKAHiTD4fa2lpk2bRnBwcD9pmOCG8tzl3126dEm1haLzE3s5+FuQlnwmcTWqqanphwG6urr+k53mF2JEunr16vcle9TZ2Znhw4djMBhISEjAw8NDaWpxTz506BBJSUncvHmT//zP/8RgMPC73/2OmpoaHaHJysoiJCREMYzbt29z+PBhNmzYwPr163FxccFut6vvmM1mo6mpSbNqW1tbcXV1pauri66uLlxdXUlOTubSpUuUlJTg5eVFe3s7bm5uuLq60traSmtrK1lZWZw9exaz2azuxEOHDsVgMBASEoLZbFZ8zGw2ExoaSnFxMYMGDVJx7XvvvceSJUt46qmnmDt3LhMmTFD346NHj7Jhwwbd1CVntLy8HJPJRFZWFhcuXCAwMJDs7GxiYmLUQDMuLo6qqipKS0vZu3evjnhJ1oGjoyPvvvsuNTU1NDU14e/vj6urKxaLhenTpxMVFcWVK1eor69n7NixfPXVV0ycOJHY2Fj2799PbW0t33//vVapYiaan59PT08PQUFBLFu2jJycHHbt2sXhw4cZNWoUw4YNo7S0VI00DQYDbW1t2O12zp07R1RUFN2EEq4AACAASURBVB0dHdhsNl0gfn5+TJs2jVOnTlFSUoLNZtPndP/+fe7cucOsWbP47LPPNOtVNhYPDw8cHBwUxxwzZgxPPvkkly9fpqWlheLiYlJSUnRu1Gw2qyjaYrHQ2tpKWloaX3/9NXa7ndmzZzNkyBCKioqora3FYDBQVVWF3W7n0Ucfxc/PT+dL6+vrMZvNmhE9adIkGhsb8fPz0+CjAQMG8O233+Lg4KBuzz09PVrNuLq6MnToUHUaFrimra2NyMhILly4oBuZ3W7n7NmzxMTEUFZWpgdLa2srHR0dDB48GAcHB5qamkhKSqKtrQ2LxcLEiROpqKjg/v37NDc34+rqSnt7O93d3dhsNh4+fIjBYNBioqmpidTUVC5cuEB5eTnd3d04OzszevRoJk6cSExMjOb3trS0YDKZKC4u1oxcABcXF2W2bTYbzs7OmM1mysrK1OOvuLiYtrY2uru78fX1xW63ExwcTEVFheKgLS0t5Ofn8+WXX7JkyZJfrhGpPDzZwQU8NRp7B7BffPFFLl682C8VzWq1kpmZSWJioopP586dy4oVK0hOTmb58uUqzHV3dyczM5Nvv/2WuXPn6n9vNP7NJsnJyQmTydQPoxPTSWlF2tvb6ezs7JcEL4Cw4Hv+/v6cPHmS+fPnA/Q7teBvp5SISZOSkrRNgV7xsiwQ6NWP5eTk6JB9amqqxkgmJyfz4YcfEhUVxaxZs1i7di1RUVHk5uaq7kxsmiTGb8qUKVrRCOkSHt4bNl5SUsLcuXN18FzCfZKSkpg9ezb//u//rnBCbm4u8+bNIzs7mwcPHuDk5KQkkDBrzs7OPHz4kHv37hEe3puh+vrrr/PHP/6RKVOmEBkZSXt7u2ZEAHrqixXYwoUL9d70xVLb29t55ZVXyMzM7AePiHSjsbERq9XKtm3b+N3vfkdDQ4NWoiIOF8Et9FYLbm5uqmdLT0/ngw8+UN2mVJyxsbGKL4n11jvvvMOGDRvw9fVVEH7RokU0NDTw4MEDcnNziYqKYu3atSqel5Qz0UsuXbpUp43EMFWyc+WAlVG/6upqwsLCtBqEXp2e1Wplx44drFq1itWrVyuZUllZyZtvvqnmE8KeyvsolZ9g5gUFBRQWFiqrKtir4IR9JV6yDsLCwnSCRPR/opmVtSFaR3n3hYSToCVppxsaGvQ+Tp06lfj4eK5evaqdQF/SMiwsjMLCQjXKaGlpYdmyZTQ0NHD37j8fGPtFVHwffPDB+7J7d3V1YTKZMBgMWK1WEhISyMrKorq6mtbWVrKzszVFqqqqiu3bt2MwGHBzc2PBggWMHj2aRx99lN/+9rcEBASoGeEHH3xAY2OjnjCenp709PTQ0dFBbW0toaGhWCwWPcmgd6GNHDmSwYMHExUVRXt7O3l5ebpIpQWxWq10dXUpK7d37158fHxIS0sjJSVFR8E2bdrESy+9xL/9278RHR2Nn58f586d4y9/+QsbNmzgxIkTBAQEkJGRQUZGBseOHWPkyJEUFRVhtVqx2+1UV1fzn//5n+Tl5VFfX091dTU1NTV8++23vPDCC6SkpHD27FlMJhM7duzgzp07GAwGMjMzSU5OZt68edhsNu7fv09ERAQGg4EjR45gt9sZPXo0Xl5elJeX6wSHo6MjDQ0NjBgxQl9cJycnxetiYmJwcHCgoqICi8XCkCFD6O7u5tq1a9TW1mpO79NPP01XVxcAn3zyCYB+HpvNhsViUdv/jo4OOjo6+OGHH9i4caNiopKV6uLigtVqZdGiRRQXF+Pl5YXNZus3Z9rT00NcXBzvvfce69atY+fOnQpT+Pn50d3dTWlpKUVFRSQnJ/Ptt99SVlbGwIEDCQ0NxdvbW3NY6urq+Otf/8qpU6dwc3PDwcFBzRnmz59Pc3MztbW1tLe385vf/Ia4uDh2796N3W5n8uTJ1NfXU1FRgdVq5eeff+bGjRvMnj0bo9HIjRs3NDBrx44dXLhwAbPZTF5enoqZDQYDZrMZf39/7HY7Y8aM0U2qp6dHMzmqqqoIDAzk8OHDvPfee2zZsoVnnnmGuro6mpqamDNnDvn5+UCvTnLcuHE68lZeXk5QUBD19fX6Xvn7+9PV1UVhYSE5OTnY7XaNGxALOcn2ePXVV/nxxx81J8Tf35/8/HxaW1s5ffo0J0+epKOjg66uLo1OCAgI4O7du7i6ulJZWUlzczNdXV24uLioTf6lS5coKytj0qRJnD17VtvsiIgINaJoaWkhPDwcd3d3Jk+ezOLFiykuLmb37t289dZbv9yKb8CAAYp9ifBRqgcRwTY0NLBixQrKysrIzs7GycmJmzdv/lN3jJ07d/LDDz/Q0tLC1KlTSUpK0sUqujI3NzeWL1+Ot7c3Bw4c0A2t78YmUwRGo1GJlL8/9QR7koXn6elJVFSUSg2Sk5PJzMzkjTfe0Mqx73xseHg4s2bNorKyUr3ZpPoUrFNOSEDV+xKRGBISoi4rRmOvk0ZBQQGvvfYaJSUlREZG8sEHH5CUlKSYYUNDA42NjTzxxBPExsaqq4ZMSvTFeaKiotiyZYtiaWfPnlXgOioqij179uDs7IyTk5MO2gupsWnTJkpKSoiLi+PDDz9k0qRJjBo1SrG9vtMVfSdkUlJSmDlzppJH0qLL86usrNTJCLnfZ86c6Ye/3r9/X+3os7OzmTdvnlY7wvQXFBSQnp7OwYMHaW9vV3PNpKQktm7dqhbrpaWlhIWFKaEitltRUVFaAbq7uytpsnnzZnbu3Mnt27cVqxSjhuHDh3P16lUWLlxIQEAAM2fOZP/+/YpPFRYW9puUEAwaUEdl2XjCwsLUgkrWTlVVFbt27eKbb74hKSkJf39/nbYQwk/0dfL+Cgwi6X2CBUoKnDwzT09PNfno6OhQxrmwsJCSkhKtusTrT37vvqYFQsx0dHSooxH8LSqyL6EpecNGo1HnsUNCQjRKVqrShQsXYrVaCQsLU8LrfwoU/0VsfN3d3SrYFHZIylkBb8PDw5k5cybTpk0jNTWV6upqneU1m82sXr2alStX6kZ4+fJlAObOncvGjRu5efOmkhDjx4/XVkUs4tvb25X5lZdO2ozq6mrN0BU9GtDv95TFKfOCcXFxXL58WQW7IvmQ3FkZlA8ODmbs2LFqoS/zpbLgS0pKWLBggUZnirZpyJAhCvbW19dz+/ZtOjs7dQxLBLVCBIkA+YknntBcEPlZb7/9NrGxsSQlJWEymZg+fTopKSls3LhRw5zCw8OprKxUPWNkZCQtLS0EBQUpWzd79mw2btwIoCatRqOR1NRUbRUF9JYNqK/XIfwNgujb+srBIu4uMg3z+eefq0ymurqaFStW6OHj7e3NiRMnaGxs5OLFi8rSysIUZl5aa/n7voee6NTk+csiE9NN8amTyQnZbAWWSEtLIyAggE2bNqmmbfz48TopcfDgQdLS0hR7S05OJiMjQyECEbx3dnZy5swZhW+++eYbndgRzz3ZTOQ+yjRNVlYWixcvxmQy8fPPPxMbG8vWrVs1HEikS4J3ShcjxIkc/KLPE0mLWElB7wz2mTNnFJ8TTeeQIUP6scFyXwFVCYhlmFx95TalpaU6CnrmzBnWrVuHm5sbf/7zn7X9lzB7f39/nUqR79s3qP7vr19Eq7t+/fr3Y2JiqK2tBdAZWZPJhNlspra2Fj8/P1paWrhz5w6hoaGMHTuWCRMmMHDgQGbMmIG/vz95eXkMGjRIA5BjY2NZu3Ztv1hF6FXnT5gwgfDwcEJCQggNDeW//uu/NGSltbUVk8mEi4uLxlCKOaosREl/amhowMXFhdraWo3jE0IgICCAMWPGEBQUREJCAnPmzGHPnj3s2bNHXZX//Oc/c/r0aby8vLDb7ZrTKmTJiBEjmD9/Pvv37+/nXJycnExVVZXOFXd2dmI0GhUuMJvN+Pj48Mwzz5Cfn8/u3bt57rnncHV1JTU1lYSEBDUMGDNmDFFRUZSVleHn50d6ejpff/01r732GhcuXOCZZ57h8OHDPPPMM8yePZvHHnsMo9HImDFjGDRoEBcuXKClpUUdTJqbmzXLZNGiRQQHB/Nf//VfOpXg5eVFfX09DQ0NDB48GEdHR31hXV1dMRgM2O12ysvL1QZdSKfHH3+cqqoqDAYDqamp/OY3vyEgIEBlTkajEbPZTFhYGCKREpvy1NRUqqqqGD16NFeuXMFgMBAVFcWzzz7Lhg0btP2Kjo7m+vXretju2LGDhIQEvL29leRwdnZm2rRpyoAHBAQoIVNbW0tRURFLly4lOzubpUuX8r/+1//i4sWLJCQk6CFbXFysKXQ2m43i4mLa29vx8/MDesH+oUOHcv78eSXJysvL8fHxoba2FpPJhLe3t64bHx8fhQJOnTpFeHg4ERERNDY24uzsrJ+3vb1d21GBG5qamvD19cXBwUEJJuk2bty4wZ07d/Dx8eGRRx6hvLyclpYWfH19lRSUTVAKD3kWfZ+rkCB3797t9y4PGDBAoQqj0YjBYMDHx0djRyXpsLCwkOjoaEaMGEFRUREtLS388Y9/5Ny5c/j4+BAUFKTxnM7OzmRkZLB48eJfbrzkhx9++L67uztms5nW1lZ9kJ6ennoDhw8fzueff46bmxvjxo0jPT2dxYsXs2LFCsrLy6mtraW1tRVPT09u3bpFWloaL7/8MrW1tSQmJvLjjz/qz3NxcWHMmDEsXbqUMWPG4OjoSHZ2NmVlZcpwNTU14eDgQEdHBykpKXR0dFBWVqYvqdFoVDyiuroaV1dXjRSUWVcPDw8OHTpEaGgodrsdX19fvLy8+Mtf/sLNmze5evUqcXFxrFq1Ch8fH7Kzs5k4cSK1tbU0NTWxfft2SktLsVqtDB8+XBnOwMBAPD09KSsrIyIiQnVZHh4eNDU18dNPP9HQ0MC///u/c+nSJVxdXTlw4ADJycls3bpV8dLi4mLsdjt79+7l1q1bREREkJyczPr164mJiaGuro7k5GSys7M5cuQIQ4cO1TjMU6dOcffuXTo7O0lPT+epp55i9erVnDp1Ck9PT0aOHElHRwf79u1TfEsyXaWNb21txW63YzQacXR0xMHBAWdnZ+x2Oz09PbS0tCiuJItCIg8NBgMVFRWcOXOGffv2cejQIb766isMBgNZWVnk5+dz8uRJ3Nzc+P3vf09oaCiffPIJTz/9NB0dHZSXl9Pc3KyB8sXFxTg6OtLd3c3JkydpaGhg3Lhx5Ofn89hjj5GcnMxPP/3E5MmTMRqNvPHGG1y4cEExraamJqZMmUJoaKiy+VFRUWRkZHD8+HEKCwt57rnntBqVhSzqgfLy8n4Gqz/99BP19fV0dnZSXFyMi4sLTzzxBOfPn9fnB71VkcViUdb61q1beHt78/DhQ2X858yZw48//khPTw8mk4mIiAgWLFiAj4+PRlb6+vri6+tLQ0MDDQ0N2O12AgMDycvLo7u7Ww9kMS8Q8bKfnx8NDQ3YbLZ+sFPfzVNgDE9PTz3AHB0dGTRoEK2trTx48EAZbFdXV5qbm6mvr8fBwUFjPQWW6OzsZPz48bS2tvLqq6/S3t7OnDlz+Oqrr2hvb2fo0KFYLBZcXFz4+uuvefXVV//hxveLEDB7eXn1TJ48WRmmvop9MaUUdfiQIUPYuXMnJ0+eVK1eXxFkcHAw27dvZ+/evSrgra+vZ+PGjWq/HRwczNatWykoKNAWRX5mfHw8ixYtor29nX379qkQVspqmTOFvxmZ9nVwkUtU8fPmzSM9PZ3Zs2ezadMmhg0bphMC7u7uWtEEBwcTFxfH1KlTtW0We6fq6mpmzZrF3r17VegqTsoSeiSZE4LdSGgL9LKYR44cYe3atbz66qs6jSGD71evXmXdunXKLkdHR+Pv78/y5cs1oQ56baYKCgp45plnKCoqUnYuIyMDk8nEgQMHdE4Zel05XnvtNTZs2EBnZ6eKUZ944gmuX7/OvXv31ClbWlmr1ar3U0bMpB0TWEHejb5+c2ICERYWRnx8vILegLL6wggnJSXpZrRkyRIyMzNxd3fX1LGGhgaGDRumQ/7Lly/n+PHjSkhIO52ZmalY5LRp05g6daqaNQQHB6tJQV8Hnvb2dtLT01m9erVKjjZv3kxWVpZO9AQEBHDw4EG13hc7tYaGBqZPn059fb2ynmlpaezdu1c/a1hYGNDrJyhYsOg/RSwuImOx5Bf8WpIHZ8yYwb59+/o5Crm7uyu2J0J8wTUFx5O2tG9qobyrsl5ExyiwgMlkUvu0J554QiMmZJRQtK+JiYk67idTMM7OzoqDe3p6kpiYqEa0VquV1NRUrly58g8FzL+Iiu+jjz5638vLS5nc9vZ2FR+6urrqP3a7nf379wOo+DQkJITy8nJcXFzw9vZmxYoVrF+/Hm9vb9rb2zUvNjQ0lJ6eHg4ePMihQ4e0XA8KCuLkyZO8/PLLvPzyy/zqV79i4cKFHDt2jM7OTlpaWhg3bhw2m03ZMTnZPD09aWpqYvDgwVqd2O12LdvFm83NzY1Vq1ZRU1PDl19+ya5duxTAv3//Pn5+frS3t9Pc3ExERASHDx8mNjaWSZMm8dlnn3H//n0uXLjA008/zbhx45g4cSKLFy/m0KFDbN26lYkTJwJom7V582ZGjx6Nt7c3e/fuJTU1leTkZIKDg7ly5Qp1dXVUVVUxYMAA/Pz8WLVqFc8++6x+ptu3b5OSkkJxcTE5OTlMmTKFrKwsysrKNLS7qamJr7/+mitXrmA0Gjlw4AAxMTEMHTqUgIAArly5QmRkJIWFhbz11lvcunVLw7MDAwOx2+1UVVVhNBoZPXq0Ei4CRwhcYLfbcXBw4OHDh9ry1tbWalUo4L/dbsfPz4/Q0FAiIiKYOXMmzc3N/PDDDwQEBJCfn09TUxMjR47k1KlTTJkyherqajZs2MCf/vQnnJ2d6ezsVPLK0dGR4cOHM23aNIqLixXfslgsJCQkUFBQgNlsxmazERsby7Fjxxg8eDC1tbWMGDFCN7379+9js9koLS3F0dERs9nMzZs3cXJyYvDgwUpmmc1mXF1d8fDwoLa2luLiYgwGgzLl7777LiaTiXPnztHR0aERogcPHsRkMuHs7IyLiwt+fn6MGjWK+fPnc+vWLc6dO0djYyM1NTUsXbqU06dPY7FYMJvN+t5ArxjZxcVFqye73Y7BYKCyshKz2awbvuTjSIVnNBppbW3F0dFR9Xhjxoyhq6uLoKAgysrKVBrm7OysnzEoKIi4uDjmz5+Pv7+/GpbK+pEW2d/fXw0VfH19yc/Px263c+bMGRXTJyUl0dXVRXt7O6NHj8Zut+Pj48P27dv/acX3i9j41q9f//7YsWNxcHDQmU8RMxoMBvz9/XFxcaGlpYWOjg5u3ryJn58fRqNRpSI+Pj5s2bKFDRs24OjoSEVFBUOHDsXJyUm1ZEFBQURGRrJu3TpWrVrFG2+8wfjx47lw4QJ37tzhq6++4i9/+QtdXV10dHTQ0tKiY3S1tbXaZgnmd+/ePRXfCr7W0tLC4MGD1SCzvb2d8ePH88knnzBlyhSCgoLUWr+6ulrlMjExMTz33HPYbDYlDk6fPo2fnx/vvfce9fX1uuFevXoVV1dXZs+ezezZs4mIiCA0NFStwMWCPDQ0lN27d/PZZ58xefJkAgIC+OMf/6hehxaLhbS0NOrr67lx44ZWkElJScTFxREfH09MTIw6iXz88cfU1NRQXl5OcXExeXl53L59m9bWVnx8fBg8eDBVVVWkp6dz5MgRduzYwRdffEFQUBBNTU3cu3ePDz74gNWrV9PT04PZbMZisVBdXa2svrzwzc3NQO+L39HRobjX/fv3Ve5gNBqx2Wy4uroSFRWFq6srAQEBPPfccyxbtkxZRMnmdXZ2pqKiQjNIkpKSmDBhAnv27GHixIm66FxcXJg+fbqONB46dIju7m6tRuLi4jh06JDic25ubgwcOJDi4mI1zHB1dWXs2LFYLBb8/Px48OABQ4cO5ejRowrCe3t7k5qayuHDh1VGIptSfX29HgwGg4Hi4mJWrVqlzLU4Jb/11lscP36cy5cvM3HiRFauXMmPP/5IREQEU6ZM0ayMU6dOERMTw4wZM2hubsbPz4+SkhJqa2u1rRSXZVdXV2WY3d3daW5uVtY/MDCQ0tJShg8fjqOjo65JAJvNRltbGy0tLfq1UhD4+fkxaNAgvL29SUlJ0SS/mJgYdu3axYkTJzAYDHrvHB0dgd7K3sPDQyU94tzj4ODA0KFDMZlMSnAZDAaam5vVdWnbtm387//9v3+5G98HH3zw/ujRo+nu7laWVvA6AUhtNhs2m428vDxWrFiB0WhkyZIlvPzyy/zbv/2bugrPmDGD0tJSXayPP/44BoOBOXPmkJ6ejq+vL8eOHWPbtm1s2bKFnJwc1UwJNubn50dtbS0PHz6ktbWVf/mXf6GsrIygoCBcXFywWCx0dXVhs9kwmUw4Ojr2Ixak3Je/q62t5YUXXtCKNiQkBH9/fz777DOuXLmCh4cHfn5+jBgxApvNxrFjx8jLy1OVe3Z2NrNmzeKJJ57QDILMzEw2b95MYWEhy5Ytw8vLi6amJn73u9/h5OTE888/j5eXF4cPH2bkyJGEhIQwfvx4Ro8eTX19PWFhYSxduhQ/Pz9iYmIwGAxERETQ0tKiNmBHjx4lNDSUxMREioqKKCoq4vDhwzz99NNMnz6dtLQ0rbJCQ0Ox2Wx4e3tjs9lIS0vjwoUL4oKLs7MzAwcOpKCgQCdi6urq+s3kSrUHKC7U2NiIr6+vWkRZLBY9GIcNG6YH0fr166mtrdVQqWeeeYa//vWv+Pr6aiV069YtXF1d1ereYrHw1FNPceHCBaqqqggKCqKtrY3i4mLS0tIYOnQo7733njKGgwYNYvfu3fz2t7/Fx8dHD2MPDw/GjRvHyZMn9bCurq5WGYqPjw/d3d1kZGQoOfHgwQPsdjsXLlzAbrfj7e2N2Wzmq6++0gkFq9WKwWDAZDIRGRlJdHQ0M2bM4Nq1awwYMIC8vDxiYmKYPXs2zz//PK6urrS1tXHlyhXOnj2Lm5sbw4cPp7OzUzWLiYmJuLq6cuzYMcUADQaDxk6KgYCzs7NmVgwePLhfEJEQJW1tbXrwCBZrtVq1SJDZY4PBwIABAwgNDSUqKoopU6ZQXFxMfHw8K1eu5OrVqzQ3N2M09rpFBwUFMW7cOIYMGUJQUBAODg7cvXuXwYMHK+YnBhFNTU3Y7XZiYmIwGo3k5eVx48YNvd+/6I1v8+bN78sJI4yevNBms1mnKQQIP3fuHCkpKdy6dYuBAwfy2WefcfDgQa5fv47NZqOwsFCnE+Li4mhoaGDr1q3s2bOHXbt2kZubS21tLcOHDychIYFDhw5RXFxMbW0tjo6Oin8EBgbi4OCAv7+/auzKy8v19xDa383NDavVisVi0Y26rwi6qamJIUOG8O2335KTk4OTkxNhYWFaVaSkpDBmzBhycnIICAigtraWiooKnd6oq6vj888/59KlSxQXF6sfWlBQEGFhYTz++OOMGzcOb29vfH19uXLlCocPHyYhIYHZs2czZcoUoqOjgd5KSljdHTt2YDabCQkJITIykp9++omjR49y584dHBwcFC9zcXHhqaeeYsKECRw/fpzs7GwuXbqkFvlms5mioiJiYmJ48cUX+fHHH5k5cybbt29XqYeESVssFgYMGMCAAQOwWq00NTUpxidZE32ZxSFDhtDW1qZjZiLk9vPzU6IkKyuLZcuW8Yc//IH9+/drWI2bm5vKk8aNG0dhYSHjx4/HYrFQWlqqOGBUVBQ1NTUUFhbq7xMREaFf193drcD8v/7rv7Jv3z6Kiorw8/Pj7t272Gw2qqqqyM/PJzw8XGGaqqoquru71U5eMEkHBwdcXFx0jOutt97i0qVLLFy4UAkBEf+KtColJYXa2lqCg4Npbm7GbDaTkJBAcXEx169fJyYmhuHDh+v/liChtrY2Tp48yciRI7FYLBw/fpyZM2dy48YNhg4dSn19PW1tbdy5c4exY8dqrq7NZqOxsREHBwdCQ0MxGo2UlZURHx+vz8fR0ZGQkBDtkIR9lbVqMBh09GzgwIGaVWw2m2lubub777/n1KlT1NbWavcjM8QhISGaInjt2jXMZjPe3t64uLhQUVGBi4uLYqRBQUEEBAQQFhZGQ0MDJSUluLq6cvjwYZYvX/7L3fg+/vjj98eOHas3zmAw6EnXV8zY3t6uL6YIIE+ePElNTQ2+vr68/vrrJCcnK1B75coVrFYrycnJ3LhxAwcHB3x9fXn00Ud5/PHHeeSRRxg6dCjJyckkJSXpn3V1dUyePJmIiAj1IKupqVEmzWAw4OXlxcSJEykvL8dgMOhMpfwDKMvb0dFBc3OzkjdRUVE8+uijWqEePnwYm81GQUEBn332GXl5eTraM3PmTLy9vfnd737Hr371K65du0Z+fr6aPVZUVCgbtmnTJlxcXLDZbBw8eJBhw4bx0ksv8eOPPxIYGMjw4cNpbm4mLy8Pi8WCxWIhKiqKO3fu4O/vz9q1a2lra2PgwIHMnDkTkRhVV1ezdu1azp07x3PPPceSJUvYt2+f6vskwPzWrVvU1dWRnp7OunXrNAFr3759dHZ2MmLECMxms+J9UjE4Ojri6uqqMg05WATfa29vp6enBwcHB0aNGqXPyWjsDV3ftm0bO3bs0CD2l156iS+++ELfIekeIiMjOXfuHIMGDaKzsxNvb29Onz6N2Wxm0aJF1NTU4ODgQHR0NBMnTmT37t0MGjSIjo4OQkND2bx5M2+99RYxMTH85je/4dixYzx8+BCbzaYHn1Svksks42niUiwbiJ+fH6dOnWLixIl89NFHDBgwgFOnTpGUlER9fT13797VzqKvZ6PBYCA6OpqbN29SUVFBWloabW1tXL9+ne7ubqKioujp6eHKlSu0tbVRW1tLXV0dnZ2d1NbWYrVa2bNnD2vWrGHLli14enpy8eJFZhas2wAAIABJREFUuru7KSoqYsqUKfj7+9Pd3U17e68J6Y0bNxQDnThxIq2trWqT5u/vT0xMDN7e3ty9e1eLFiH6hDSsra2lpKRErbO++OILzp49q/ZuLS0tKjxubW3VSjInJ4eSkhL8/PwoKirikUceIS8vT2GGMWPGMGrUKDw8PBg6dCgnT56kubmZpqYmTp069U8nN34RG9+6devef/zxx3F1daWzsxNnZ2e6u7tVoCwvrlSB0CuAXLx4MUFBQbrQTpw4wa5du6iqqsJkMjF06FD8/PzIzs5m7NixjBo1Sk+OhIQEioqKyM/Px9HRkaeffhq73c758+eprKykoqICgHHjxnHz5k2qqqro6urSRSkKd2dnZ9XuySKQjU/Kf0dHRywWC3/+8581/Sk2NpabN2/y008/YbFYmD17NkePHiU3NxdfX1/mzJlDdHQ0WVlZ5OTkcOHCBb744gsKCwtJSEggIiJCsxrCw8MxGAzExcUxY8YMXn75ZTw9PVmxYoXay0+bNo39+/dz+PBhLl++zJUrV7Q9+PTTT3n22WcZOXIkFy9eZPv27QQFBTF06FAeeeQRhg8fzsSJExWUHjRoEI888ojqK8XAVbDVCRMm8MUXX/DCCy/Q1tam8pHJkydz7NgxGhsbMRgMansvEiH5UyoFqR5kYTz//PN8/PHH/Mu//Au3bt1ix44dig9KFsPFixcZMGAAzc3NuLi44ODgoG3cnDlzuHXrFi4uLoqjJSQkUFJSwogRI/RAe+6558jIyODBgweYTCbGjBnDwIEDSUxMJDw8nCtXrrB//37dlJqbm7HZbP1YSBGu22w2goKCKC4u5sqVKyQmJmIwGBSbLi4uVpjAbrfT2tqK1WqlsrKSzs5ODd0KDAxUEqSuro6EhASam5vp7OxUlvT8+fOMGzeOlpYWLBYLTU1NlJeX4+/vT0hIiIqPR48ezQ8//MCsWbMoKipSyVRVVRXFxcW0trYyceJEIiIicHZ21hiA1tZWEhISyMnJUcOB2tpavLy8GDFiBMXFxXh4eNDR0UF4eDjDhg3TqZyEhAQGDhyoRhDnz5+np6eH7u5uysvLMRqNisE3NDTQ2tqqHZbNZmPkyJE6bhcZGYnFYsFgMOi8t8Vi4ZNPPiE6OprKykpcXV3561//yttvv/3L3fi2bNnyfmpqKhaLRSlumSft+0L0PUlMJhN3797FaDSya9cuenp6GDBgAJMmTVIhaEdHByaTiaamJtVQCSYF4Ofnx71798jNzSUzMxODwYCrqyujR49m0aJFqqm7ceMGLS0t/QKkRZM2c+ZM/XmiH3JxcQFQllcWsOCCJ06cYOvWrSxdupT169djtVp59tlnefLJJ5kzZw5z587l5s2bHDhwgIMHD6rt0W9/+1va29vZv38/QUFB5OfnK/lQVFREa2srZ8+e5YknnsBgMPDxxx/zwgsvaDuUn5+vQLmHhwdz5sxh8ODBREREUFFRQXR0NLNmzaKjowNPT086Ojr4y1/+wjfffENNTQ1Dhw6loKCATz75BKPRSGhoKFVVVdhsNkaMGMH48eOZMGECq1evJj4+HpvNRm5urkqSZHpDfmeJX6yvr9fnKviNMIaC+3l4eJCenk5dXR3Dhw8nLCyMs2fPKv4TFBSkqXTiliNY4KhRo0hLS+ONN95g3LhxeHl58fDhQ+7cucOQIUOw2WzcuXOHkJAQxQOFZff09GT+/Pk8//zz7Nixgx9//BGbzUZDQwOOjo74+vrqrPfkyZO5ffs23t7eDBgwgIqKCux2O4sWLdJxwStXrvDII48oBibjfQEBAbi4uNDa2qrEgxyo0HsANzc3ExYWhre3N87OzgQHByusUlxcrC4yhYWFjBgxQjWBDg4OFBUVadCQzGaPGDGCu3fvEhMTow5BFouFn376ibKyMpUfzZw5U12MysrKKCgoICIiQsfkPDw89BBxc3PD39+fhIQEzp8/T3BwMNOmTdONKjU1ldraWlxdXQkKCsJgMHDv3j0cHBzo6enRaq2iogKDwUBoaCi1tbX8+te/Jjs7GxcXFyZOnKipbTU1NZw/f566ujru3r3L5cuXSU1Npbi4mFu3brFixYp/uPH9Ivz4urq6FM8KCQlRt5O/H3OR0ht6R7ZERb9o0SICAgLw9fVl3rx5pKSksHjxYt555x2dxwV0bjU7O5uSkhLVWvn6+mIymcjNzeXixYtkZGTohIUMigvYLnij/B6ZmZk6jSAnfl8LcPn69vZ2MjIy+OijjygoKKChoYGsrCytAouKigC03JeEub5+fbGxsZqvceDAAVJSUoiMjMTd3Z1PP/2UsWPHEhISop/znXfeISMjgyNHjqin39SpUzVlKz09XU1W5RKXkrKyMtzc3DAajcTHx+Pu7k5kZCSpqamsWLGCuLg4IiMjmTp1KomJiXh4eHDu3Dm+++47ZflEP1ZZWcmaNWvw9vYmOTmZ9vZ2vv/+e9zc3HByclIdmFxSMfWNEZT7t3fvXl577TVmzJihfoF9Pd6Emfb09NQJIKk6xFRUogrFJFP+/8WLF3nmmWdUI5eYmMiaNWvU1UUSy+7du6f3zNnZGX9/f53VNplMmEwmnaQxGo2kp6ezceNGdfq5evWqBmj3/byCD1utVpXWyPsvI1geHh5UV1frSKaPj4+69kimshiQSgsoIVeBgYE8ePCA5cuXawqbyWTS59XZ2YnJZNL8EfGlFE9H0e+lpaVx9epVKisrgd6smpSUFJUCZWdns2XLFkwmEyEhIZqol5qaSnh4OEeOHMHb25ukpCSCg4M1BFzGIfvObMs7KPPCgM74SkBSTU2N/uyamho2btxIaWkp/5NG+RdR8a1fv/79vmEpMsfp7OzMoEGD+pEbMpJTXl5OV1eX6tKkvxfG88qVKyrqffPNNzl58iTr1q1j/fr1VFVV4erqSkhICHPmzOFXv/oVzz77LG1tbZSXl1NUVKRzmbIJiM8aoF58InkxGo3U1tZqIIzNZtPFKD5mglmFh4ezcOFCpk6dyosvvsjAgQMVWL916xaPPvooP/zwAy+++CJFRUXYbDbOnj2rLVF5eTlms1nF2Xa7nVdffZWysjLy8/M1b+L06dOUlpZSXl5OcnIyr7zyCj/88INqxLq7uxW0rqqqYsqUKVy+fJlNmzbh6+vLd999x507d8jNzVXSJicnh/Pnz9Pe3s64ceNwc3OjpaUFLy8v9VE8ePAg7733Hr6+vlRUVNDe3s6tW7d0rE0wQZH0SLUiWJxIRuS+9Z0GqK6uJiIiguLiYt58802OHTsG9Ip2g4KCmDFjBgMGDODSpUvExcWpFdJLL73E4cOHuXfvnj5Hac+vXbvGyJEjcXFx4ZlnnuGbb77RZ5+cnMwf/vAHVq5cyeXLl2loaNAxKqnEnJycuHfvnmYkOzk5YTAYePDgAXV1dfz888/ExcUp09t3BEvgEiEN7t69qziekGhNTU14enry3HPPUV9fT3FxMa6urmRnZxMbG8vXX3+t/n5ms5lJkybxyCOPcOTIEdUEClbu5OSkZKGM2skon0xFuLi4MHPmTCIiInB0dOTBgwcEBQUp3ibW74IBy7osLCzEYrFQWFioUhR/f3+tOmtqanjjjTf47LPPKC8vV4/K8+fPawCSi4sLbm5uOjXl4uLCo48+qjKlY8eO4ejoyLVr13j88ceZPHkyeXl5PP7444otCvkluOvKlSt/2a3u2LFjCQsL48MPP1Tv/46ODgYOHIifn5+CmT4+PjQ1NWE0GpXd6uzspLOzkzFjxqhNuDxoAdtFrQ9w9+5dbt68ybFjxygpKaGxsVGNIkUVLkzouXPnqKur03YbeskNmTuUbFTR+MkkQl+cb8iQIbqgPTw8mDp1KmfPnmX37t0cPXqUKVOm8MEHH5CSksLatWuZMmUKdXV1WK1WFSqHhoZy9+5dRowYQWhoKKmpqZw+fZobN25w8+ZNTpw4QWJiIq+88go+Pj50dXWpnXdZWRkVFRX4+flp1eTk5MT8+fPVO23NmjWEh4cTFxdHeXk5N2/eVKIkMzMTq9XKqVOnqK6u1halsbGRY8eOcenSJWJjY9m1axfR0dG4ubmRmZmJ2Wzm1KlTytYKoL97924mTZpEfHw827ZtIzAwkNu3byvZIZccdMJ0ynSFv78/p0+fpqmpiba2NkJDQ1m1ahUzZswgJCQEi8VCcXExFouFiIgIampquHz5MvHx8fq9Jfu4paWFX//614wbN468vDwGDx6sP1dsqSIjI/n888+Jjo6moaEBi8WilZ3kucphPGbMGKqqqnjw4AFnzpzRed7AwECtNs1ms+rlxOLJ39+ftrY2BgwYgMlkoqamhra2Nj0cbty4wfz58/Xw8/DwID8/n9mzZ/Ptt9/qYm9sbCQ0NJQJEybg5OTE8ePHcXNzo76+nocPH2K328nLy1Pczs/PTwnA06dPU1hYyJEjRzh//jx5eXn4+/vrjLDoDCsqKtQWLiAgAKPRiBgJ//zzz7S0tODj44OTkxPZ2dlUVFQwZ84c6urqKCgo0I5HDDVSU1N1PE3ui8jXiouLdfb82rVrugmbTCYePHigEqrc3FxVV0gQenl5+S+b3Ni9e/f7/+f//B8CAgIYPnw4R48excXFRcWb1dXV6iQi7Yu0w66urppLWlJSQlpaGuHh4cTExDBixAi+++47LBYLHR0dREVFKZ7l5+dHYmIi8fHxTJkyBScnJ0JDQ4mJiVHfr8LCQhoaGnQOWE56WYiiR5NT3mq14uXlpRWSMLwtLS36v61WK9nZ2QQGBjJz5kw1xPz444/x8fHh0qVL7N69m5ycHN566y3Ky8v58MMPKSkp4cGDBwwYMAAnJycKCwsZMmQIf/jDH2hububEiROUlZVx4sQJli5dSlZWFmvWrKG2tlYT6VtbW1XfJtq3yZMn89lnn+Hi4kJ+fj55eXmYTCZtRUtLS3WCoL29nXfffZcRI0aQnZ3N6dOn+e6774iPj2fChAmKHRUXFxMREaHZEA0NDQQGBnLjxg1doA0NDXR3dxMXF8eZM2dwcnKitbVVnbH7DqxD7yY4ePBgrly5wpIlSxg1apS6Y0uw+dmzZwkPD9ehfnFHvnnzJtHR0YorBQUFMXPmTF2Ic+fO5dKlS/rvCgoKuHr1KjExMQoldHZ2cvHiRQwGAy4uLmo1Jcytg4MDixcv1sW6d+9e3n33XeLj4zXYXQS/MlVkMBi0QwgMDMTR0ZGgoCDa29u5efOmvmtDhgzB39+fnJwcTpw4weDBg7FardTX1xMbG4uXl5eyrHa7nYEDB5Kfn4/VatU2EnoJwcmTJ2MymaioqFDfOpHtiF6x7+GTkpLChQsXKCoqUglXeXk59+/fp6KigqqqKnVq9vf3Jzo6Wo0Qqqqq8PLyIiIigueee47333+fp59+WvMwfH19dW0MHTpUHW8Eexd97FNPPYWjoyMTJkwAejNlRFDt6uqqs+BWq1WrUZPJRH5+/j/F+H4RG9/atWvf/81vfkNERASLFy9m8+bNDBw4kLy8PAB1arFardTU1NDS0qLiUZFyyImZl5fH1atXuXPnDpMnT+a9995j/fr1Kmy8cOEC3d3dpKamsnHjRq5du0ZFRQUzZszg/fffx2KxcO3aNb777jvGjRuntuayEE0mE8uWLSMrK0s3wPr6eq0ABGuQxDFpcaV6cnFxUXeSjIwMDh48SHl5OXPnzsXZ2Zl9+/apjnDTpk2kpaXh7+9PYmIinp6eFBcXc/nyZRV53rlzhwMHDjBmzBg9Cb/77jt27NjBkiVLVGQtzKO0bDk5Ofz+97/nhx9+oKysDLPZzN27d2lsbMRsNhMcHKwbSHl5OT09Pdpaz549m23bthEeHk5ycjLp6emsXLmSwMBADh06RGVlJUuWLKGiokLZYaPRyNmzZ3n00Ud1QkemFW7dugWgchZZeLLpyX202Wxs27YNm83GwIEDMZlMuLq68sILL7B27VoFw8vLy1XJP2zYMGJiYv4f5t49LOo67/9/jByGM3KWkxAQyGjEkAamgYfAcsEysUzdXGntljZLr7TaSu+yLDvd2rqrVptmqbmpWWJWkibkARQZFB0UmVGEQWA4I8gQh+8f9H4Fu9t97/W7rt919bkuLkuQmfl83u/X+3V4HnB1dR0Cgxg5ciRnzpyhsrKS4cOHizzSiRMnKC0tRafTUV5ezj333MPBgweHyM97e3sP0Uusra0V3Nz169d599132bBhAzExMXzwwQf4+PgwdepUuY/29vakpqZSV1cnG18xXxSJv7KyUqwQ1GS4v7+f2tpadDqdbPwTJ04wY8YMampqRPL+yy+/lFJcq9VisViIjo4WeX8XFxeR7VfSVlarlQceeECYNOHh4dx66614eXkJH72zs1PaUKovqJgfNptNhB8U7GjixIl0d3fzzjvvcOLECQ4fPkxJSQkTJ05kypQp8n47OzvFWyUpKQmNRiMey3Z2doSGhnLs2DHKysq4efMmDQ0NjBgxQta7o6MjZ86cEbsKJYJbVVXFn//8599u4Pvkk09ednZ2JiAggIkTJzJ8+HAOHz4MDCx6Ly8vrl69KvAQ5ZsAA9O+jo4ONBoNzzzzjARJJZO9atUqnnzyST7//HMAaaqqvouafp09e5bKykpZ3Ao3pU7AtrY2Wlpa8PDw4Nlnn+WJJ57gnXfeQasdkMf38PCQibTqM6g+FSClrjrle3p6CA0N5S9/+QsPPPAA58+fZ+TIkTJQ8fPzw87OTlSYIyIiuOWWWwRBf/LkSVJSUggJCRlCN1J9qL179zJt2jTa29vlMylAbXNzswQ9o9HI66+/zsyZM7n//vuZNm0apaWlREVFCZha2Q+eOHECo9HIvffey86dO7G3t8fPz4+RI0cqzBQff/wxzc3N3HHHHXz77bfMnTuX0tJS9u3bJ4BhNfnLyMhAr9fz448/0t7eTlVVldCe7Ozs5GBRje7BSi7qENJqteTl5bFlyxZmzpxJZWUllZWVwoU9ceKEtE1URtDc3ExERAR1dXUYDAYiIyMpKSnh+vXrdHR0EB0djYeHB3FxcQQEBBAYGChMCJ1OJ/zTa9eu4eHhwdWrV/Hy8qKmpobXX39dQPI5OTniEHbhwgVSU1MlAKqyTA3GAJkme3t7YzabBQ3g7OwsUB83Nzcp/VJSUigoKOD8+fNMnDiRN954Aw8PDwZLvKmeYk9PD01NTUycOJFz585JILdarSJGUFJSwhtvvMG5c+e45ZZb8PHxoaSkBKvVipubGx0dHaLOreBbXl5eMnBRmMzS0lK6u7u5fv06CQkJ3HHHHXz11Vf4+PgI2D0kJETeg/KPUc9GKQE9/PDDVFVV4efnh6urK6NGjeLSpUsiyltaWkp1dTVxcXGMHj1a9pYKypWVlb8a+H4T6iwBAQH9dXV1pKSkkJeXB8Dhw4elH6AI4grPpfBfyk9DXXq9XlRc1qxZAwzATrKysvD39yc2NpbvvvuO8ePHixfp4cOHmTp1qvyO7OxscZMCxEMXkNG98pSwWCwyAfT395dSt6ysTIYegPQd1N8p1/jPPvtMTlulUhwTE8PcuXPl/fz000/i/fH8888TFxcn0lBKuXfnzp0A4sug4CM+Pj5y33Q6He3t7ezevZvDhw/z3nvvceedd4rBs+K1RkREUFZWxqxZs5g0aRITJ04EBprTixcv5s4772Tv3r3iXv/2229TUFDAm2++KZ933rx5wAB8Zd68eWJKrtPphpiQp6en09bWJlNTg8EgE04YOs0HhvRKBz/30NBQub+D/XjV5wkICCAxMRFfX1/y8/PR6/UYjUaZVr7zzjuYzWaOHj0qeDmlanL16lWqq6uJj48Xu1Ml2qmUoM1mM/7+/qxdu5ZVq1ZJIFAeMV1dXWK4DYgPb3V1taADlHdySkoKVVVVnDp1SqamkyZNIjExkZCQEFFBVtLwSo9xy5YtrFq1SqoPZdSt7FNjY2NFIDQ0NFQUaZTajxJ33bBhA+PGjWPZsmUCfFYgY2XZqnxklPJKW1sbZrOZpKQk6uvriYqKErvXZ599FoPBwObNm2lra6O1tVW8c3/e+1RVVeHo6MikSZPkINq+fTtms5n09HRu3Lgh+0yhHFpbWykrK6O7u5ulS5fS2tqKyWSSkh1g165ddHZ2/nbVWTZu3Pjy0qVLWbhwIQAffvihZHx9fX1SKqpenRL91Gq1ktKr/pmCKUydOhVnZ2cZhKgJmqLgxMbGClJf+YvCgGVlYWGhKNuqklWJhCpntAMHDgh/sqCgQICnoaGhBAYGimqL0u5TenOAaPiNHTsWq9VKSEiIvL9169bR0NBAS0sLDg4OtLW1MWzYMH766SesViuff/45Dz74IM7OznR2dgrBHQbwWipL0Gq1gj0MCwvjk08+4aGHHmLfvn3k5uYyduxYDAaDvNe+vj78/f25efMmbW1tlJWVceTIEVpaWqirq8NisbB48WJ+/PFH4uPjmTFjhjAx9uzZg9lspqamhpiYGFG8trOzE46op6enTD1HjBghhk1Wq5VRo0aRl5cnk3I1YFCT8e7ubmHBqB6baiF0d3fj7e1NeHi4lJwajQY/Pz88PDxk4qmGPQr0qgQ8VRPfaDQyY8YMAYaHhIQQERHBV199JUDdqVOnYjAYiImJEeUSgObmZh5++GHWrVuHu7s7P/zwg7iMKfZER0cHTU1NNDc3U1FRgaurK1OnTqWoqEjaNYGBgdjb26PRaMQ1z9vbGxcXF7Gf/Omnn6isrKS+vl5K+Xnz5nH27Fkee+wxDh8+TGtrK319fQwfPlxwlIpHa7PZhBvr6OhIXV0dycnJVFZWEhQURE9PD3fddRcbN26UQygsLIy2tjbBqKo15uLiQkpKCi0tLUIvc3Z2pqWlBaPRSExMDDNnzhQJLjVhLi8vx2q1EhAQgLe3N3q9Xuh1qiUUFRUlwO+Ojg7JlKurq/Hw8CAoKIjQ0FDc3NyEYz927FjhFd+8eZP6+vpf7fH9JqTnfXx82LdvHzNnzuT06dPExsZSXFxMYWEhOp0OrVY7xK0dfpEoH2zGrU4UpSt39epVTCYT1dXVGI1GgoOD0ev1gi9TkyV1ZWdnM378eOrr68W0R13qNQY7Qx04cACdTiep9WA9PkBUW1R28s+eAps3b+bZZ58lODhYMsz9+/fL71JT4J9++gkYCAAGg4Fly5axYsUKgoKChjjPKW06JYSg7u1jjz3GqlWrRBdOq9VKZlBWViau9upPQMyw9+zZI56tL730khDsAZKSkjCZTHJPBrtjKc041ftUA5mAgAAZVhmNRi5cuMCxY8fklFb3UrFi4Bf9N/WlvH/VPVWetcnJyQJ9Uv4tMIB/NBgMODo6ymbJz8+X9aSkoVRG5OHhId6tSgVGZaZKo6+qqkpaLsqIPTExkcLCQu6++27JpJWEvArqMAC+V5VMenq6ZG3V1dUiSw9Iv9jPzw8/Pz+pgDIyMoABnKEK/Js3bxY0gMIAuru7M3LkSGn7KByhTqcTm4OqqiqKi4tJSUmhoqKCnJwc9Ho9+/fv57XXXpPnqabXDg4OQqFTlzIAV5m7ulasWCH7LCIigvr6etlv/v7+BAcHU1xcLGrW3333nTwzvV4v2oyRkZFiaZCYmCh2AAoSpTJgo9GIzWb7F/zvv7t+EwDmpqYmCUZGo1H0tz777DNBvet0OiIiIoiNjRUMlvpSl4eHB42NjRw7dkz0wFS2pwj8ajp88OBB9uzZIzgjgKVLlxIbG0tWVhZ+fn7iG6E2r9oomzZtAgZKLCVcOhhEGxERgYeHBx4eHvL+oqKixKZSlWYVFRXAL6BlQEzMB382m83GrFmzMBgMREREEBwcTFBQENu2baOtrU1039SlVDQAdu7cSW5uLkuXLhUbSvV6Sk0XhgZ2f39/Cdqq9O3u7mbLli3CdMnPzycmJobc3FyMRiMpKSkcOHBAPD4yMjKkBzd37lwaGxulD9ra2kpsbCwXLlwgOztbaHoq2KmS9Z8XrronqmUw+PsqaCkbTScnJywWC35+flJ2JSQkkJKSAgwEbXUgKZBzXl4emzdvFnDysmXLiI2NlXZEQ0MDe/fuxc/Pj7Nnz5KZmcny5cs5efKkGN+rfl1ra6scWOoZqtdTpTLAjh07pPRXwVZNSdX9a29vx2AwYLVa8fPzIycnh61bt/Laa6+xceNGVq1aJWDnTz75hNjYWKKiooZo2lmtVqKiouTndDodycnJ4iWi1q8SfVBrUa37hIQEbr/9dkaOHCmfSYnOKoFVFeDVgR0UFMTzzz8vgzmlVKNMytW+NJlMlJSUyBpQa1mn04mJ+u23305ISIgEf6XcpCw4VftLQbiU+OmvXb+JUvfTTz99+fHHH5emq8LwjB07lqCgIK5du0ZnZ6dMjxSXV+G4VHYEyJR1xowZwIDfqBLczM/Px8vLi1tvvZXCwkIKCwt56KGH6OnpYdiwYfj6+jJmzBiqq6spKyujoqICBwcHWltbZcKYmJhIQEAAKSkpTJkyhSlTpjB+/Hi+//57odoo8KmHh4coV6h+jhpswECA8vLyIj4+fsj9yMnJoa+vDwcHBxEnPXfunGw+o9HI7t27OX36tJTyvb29BAUFiTfDxIkT2bBhA6tWraKzs5PCwkK8vLxwcnISXnJYWBiVlZW4urpy/fp1kRxX9zAuLk6UUxTkwtvbm4MHD8rk+Pz583z33XccP36cb775BldXVxwcHBg3bhxBQUHSfFcbWamMvPvuu0ybNo0xY8bQ2NgoqrlqoysdN/hFlcfd3V0EH7y8vAC4efMmgCz+8vJy4BcnL+WNooDSbW1tjBkzhkcffZScnBz5fDAg9/7KK68IvCkyMpLo6GjhEev1euzt7fnyyy958sknaW5u5osvvqCkpISxY8dSVVUl1qjqWSlsqb+/vwC0VVC/ePEinZ2dWCwWafYrSf2Ojg56enoYPnxYCmJdAAAgAElEQVQ4gYGBaDQaAVwrGTO1hpT1QUFBAZMmTeKHH34YIox79epVHBwcZCDU2NhIUVGRSDqNGDFC5Li8vb0BuHHjBmPGjOHkyZNDcLPDhw8XSI5qJ+j1evFPuX79OmPHjmX27NnccccdbNmyhbi4OGy2AYkxV1dX3NzcuPXWW4ccYBaLhbCwMB5//HE+++wzwsPD6ezsxMHBgc7OTjw9PQWhUF1dzYQJEzCZTPT391NXV0dnZyceHh5CZVQIkN80nOWDDz542WAwcN999zFq1Cg+++wzTpw4gZ+fH3/84x/55ptvCAkJEb6fqt8HY7zgF4OT9vZ2Lly4gEajEWNpJZ8UHR3NN998g8ViEVjCCy+8wJUrV0T80t7enuLiYqxWK319fbIIvb29WbRokfBJ8/PzRUJKp9NRUFCAh4eH6LB1dHQIq0P1Int7e/H29pYpW2lpqfQ2YaC/efnyZerr60Wip7e3F5PJJJJdDQ0Nollob28vr6eazps2baKvr49r167JNFNJa+3btw+TyURlZaXwXouKiqREsNlspKenc/VnPw87Ozvi4uLo7++XzCQzM5MrV67wxRdfyN+pknD//v14e3vz97//XTbGmjVrmDx5MvPmzeO2224jNzeXlStX0tHRQVlZGX5+fsKQUawXVRINfrYeHh5D/DfU81eTfR8fHxobG7l8+TJNTU1iYuPl5cWcOXO4cOECbW1t3Lhxg08++UTwls3NzXh5eREaGkpKSooIR6g+owoGgPR+P/roIxISEjh+/DidnZ3cd999nD9/HhcXFxGKVf3d2tpaEbiIjY3lypUrAm1SPiNKQsvV1RWLxYJGoxGv5hEjRogBlLOzs6xrBQlyd3ent7dX+mbjxo0TpWRA1oliGl27dk0EO5VwrZ2dnbCPLl26hK+vLzU1NSxdupT6+nr0er3AqFQZarVaRZ3ZxcUFk8nEpEmTcHR0ZNmyZezatUs8fxsbG0WjUqvVipyXEmgICwvj5s2b3HLLLcyePZsTJ05gtVrlfprNZhkkhYaGUllZKb1vdZ9dXFy4ePEiYWFhODg40NjY+NuWpfrggw9erqqqIjQ0lDFjxjB58mQsFgsFBQVoNBrmzJkjC10tFDUKVxAJ1fyGgayvs7OTlJQUxo0bR3h4OFFRUYSFhXHq1CmWLFlCWVkZhw4d4tKlS9y4cYOxY8eKofHRo0dpbGykpaWF+vp6MQ1XvhJGo1EEDZqbmzEYDLi6ujJu3DgOHDiAnZ0ds2fPpra2lsrKSkn/XV1dJeNzc3MTmtbf/vY3Dh48yGeffUZpaSkmk4menh6am5t54oknZJI3efJkfHx8OHjwIL///e9FLv93v/sdCxYs4P7772fUqFGy2UePHs3tt98uaiQJCQlMnz5dgMTKUCYuLk6Ao2FhYZw7d47w8HAhoqufSUtL4/z580yZMkWUh8eOHct9993H4sWLefPNN6WxfenSJXp7eykpKeHll18mNzeXxx9/nIaGBnJzc//FGaygoEAYJ1qtlrq6OhleqTJMKYx4eXlJf/bmzZvcdttt1NbW0t7ezi233EJfX98Q8xoF/lbMA5XtKAN4Dw8PZs2ahaenJ9HR0QKTUKwGtbGsVitffvkldXV1TJ8+ne3bt5OQkIDZbOZPf/qTYNmU6bgK4j09PbS1tQmWbrD+oM02YD6kVKwVHGqwl8ioUaM4duwY8+bNo6Ojg+bmZoKCgiSgKVn7wa0ZJZPV0dFBTU2N4DFdXFwwm83ExcUJDEy5ramyU6vVCrZRiaO2trZy+fJlLBYLU6ZM4b777qOzs5OQkBC8vLxEyNbOzo6ffvpJxHybm5txdXWVrC42NlaqAgWNmTdv3hANw1tvvZX4+HiuXLkiVE0vLy+CgoLo6urC29sbLy8vfHx8CA4OJisri+LiYmpqarjvvvt4/fXX+eGHHygtLWXFihW/3cC3YsWKl2NiYkhKShKzlPDwcB555BEeeugh7rjjDhITE+nr6+PIkSMi16MCkuI+enl54ebmhs1mo6enh0uXLjFz5kxJkVXmeOrUKc6fP09RUZEIIKpsR1FxAKHCdXR04Obmhr29PYcOHeIf//gHR44cIS8vj8uXL2MymSgoKODy5cvCU2xoaJA0XYFvFY6vu7ub/v5+Kc9bWloE2KosEEeOHMkjjzzC9u3bJaAraM13333HRx99xN/+9jc+/fRTSktLuXjxIpcvXx7C89RoNNTW1spGtre3x2g0Mn78eOzt7QWvBjBhwgRZ6AkJCUJJUwICc+bMwcHBAQ8PDwEC63Q6vv32W5GZV2KnnZ2dnD9/Xpy+7rzzTlauXMnYsWOFLQEDZaqaZn/00Ufs27dPwMuqfFeZUW9vL1OnTsVoNNLY2IiXl5c44B07dgx7e3uysrK47bbbcHV15fz58wQGBlJeXk5aWhpfffUVbW1tZGVl8e2334rEueLMTp8+nezsbPbs2SPS/CrwKpsDNdHX6XSEh4djsViorKwkKytLcHelpaUimqrwhopqqX6nt7c3dnZ2Akyura0VuTQnJydqa2tF8CA+Pp7AwEDMZjM2m02ejVIj6u3tFaGE9vZ2sQ89fPgwS5cupbKykqVLlwrLBSAlJQUvLy8ZAGk0GjIzM6mrqyM6OhofHx8Z+DQ3N7Nz504BEvv5+XHs2DEuXbrE5cuXuX79ujjbnTt3jvHjx9PU1MQnn3wiCjNqom61WoVhpFoqJpOJq1evMmfOHG699VauXbvGsGHDGD58OGPGjKGurk5ex2Aw4OPjI7jJ3t5eUlJSKC0t5dq1ayQnJ1NXV8f7778vAObfdKn76quvvuzs7ExZWRlubm4cO3aMI0eOCMTixo0bnDlzhrFjx3LkyBF6enpobGxkxIgRciID8nBV01uh4u+8805ef/11WcB1dXX4+fmJt+qIESMEVhAZGSkUJWV1qehmrq6u3HPPPcyfP5/JkyeTm5sr/b+Wlha6urpkM6n35ebmJpneYA4vMESyW8FxTp8+zSuvvMKMGTN49913qa2tlcD5wgsvYDabxQO1s7OTpUuXkpWVxVtvvUVvby9msxkXFxcKCgr48ssvue+++9i6dauUioNNnJQsv/pSun4KRP7ggw9y1113ERoairu7uzyPa9eu4erqip+fHxMmTCAtLY1hw4YJhzc4OBiDwUB4eDiPP/44gYGB+Pv786c//YmPPvqItWvXSiBetGgRPT09fP7550P40IPZG+qAGD58OA0NDQwfPlw2vCLFBwUF4e7uLj0z1dCPjo7m9OnTBAUFYTAYePHFF/nyyy+F+XH58mVGjBhBeHg4e/fu5erP3snHjh0Tj5SYmBi+//57gdMAQs1zdXXlk08+Yc6cORw7dozRo0eLiouqWJREugIfR0dHC6hYfbaOjg5CQkKGwJeUjl1FRQVnzpwhICCASZMmMW3aNO666y7S0tK4fPmylOOKCqfu2/Hjx1m+fDm+vr4yKVa81vPnz5OWloaTk5PI0Stcore3N8899xwmk0nYVI899hj33HMPaWlpXLt2jR9//JHi4mLKy8s5c+YMZrOZ/fv3s2fPHo4fP87DDz+MzWajqqpKzKC8vb0pLS2VZ6csPaurq9m1axf79+8X+bm6ujoiIiIYM2YMDQ0NYr8aHBzMmDFjiImJIS0tjdzcXNrb2wkODpbWk5ubGy4uLlRVVbF8+fLfbuB77bXXRHpewTAsFgsjRozAbDaTkJBAUFAQx48fp7m5mXHjxlFTU0NPT4+M7tXpqspK1citqalh1qxZJCcn4+zszOeff05HRwd+fn6cPn2a3t5efHx86OjoYP78+eKT2tzcLKrJgDSajxw5ws2bN5k4cSK///3vOXHiBDdv3pSMTaHTlVYZDMASFGdXlZgajWZI7wjggQce4K9//SvffPMN7777LhMmTCAlJYWioiKSkpI4d+6caOXdvHmTNWvWUF1dzRtvvCGMg/CfjX1CQkIICgqitraWkpISGhoapHwzGAwcP35cOJgmk4ne3l7Gjx9PXV0djz76KK6urmzfvp3vvvtO9OpGjx7Nvn37KCgoAAZgM15eXpSXlzN//nzp+agMs6Ojg6ioKDZv3kxFRQWvvPIKXl5elJWVyQGlWhpNTU1S6qrnp9FohgQ+e3t7xo4dK31LOzs7xo4dS2BgIKWlpbS0tHDu3Dn6+/tpamqSAKT6a++//z7u7u5s27aN+vp66ZMqmS6bzSaDtLvuuou+vj7s7OzEe0Rt3uDgYDQaDXFxcQQGBkrQmDBhAhcvXqSjo4Njx44JJ1mrHbAfUC2Ozs5OTCaT9EXvvvtunJ2dGT58uNALW1tb5cC0WCwEBgbywgsv4O/vT3Z2NkVFRUyePJnExETuvfde7rrrLhwcHCgvL0ev1zN9+nT++te/UlZWxsiRI8U0XmFEL1y4QGdnJ8ePHxeznsrKShISEoiJieHTTz/l+vXr/PDDD6SkpHDx4kVycnI4deoUJ0+eFK3LhIQEKioqmD9/Pj09PdjZ2UmGqg5hPz8/oqKiBFKUlJQkbKLByAVVqc2ZM0dMvmCg+nv++efJzMzk2rVrVFRUyHtUnyMiIoLAwECMRqOwkzo6On7bPb61a9e+7OnpKU5bLi4uVFRUCDbn22+/lexMcTEdHBxkUalsTEEElBJGdHQ0lZWVMjwYPnw499xzD+PGjcPT05N58+YRGRmJXq8nKiqKqqoqObmbm5tFOVnpgk2dOlV8Fs6ePUtubi7Tp09n1apVjBo1Cg8PDx599FFGjBghYFXVh7HZbBKcFZBZBcvBDfzMzEwxmi4oKKCoqEiwh3FxcfT09JCSkkJTUxObNm0iNzeX/v5+fHx8hBPr5uaGl5cX8+bN4/PPPxc+4/Tp09FqtcyZM4fMzEyKi4uxs7PjxRdfpLS0lJqaGhmiqMGMu7s706ZNo6CggLvuuovvv/9eeJfHjx+noKBAejTPPfcc9vb2lJaWilrHu+++y9SpU/nv//5vJk6cKJS68vJyvvzyS9544w3a2tpwdXUVV7zBoggq8/P19SU9PR0PDw8hpauGvgK0t7W1MX78eDGp7u3tJSkpiRdffJHCwkLOnDlDUlISmzZtQqvVUllZSWRkJMOHDycgIACNRkNVVRVNTU1ER0dLf0pNW/38/IiLi8Pd3V107Kqrq0lNTaWoqIjm5mbBnep0OplEtra24uPjQ2RkpKgT9/b2cu+993L33Xfz1FNPkZCQQFFRkfBinZyc6O3txdPTU7Ln6dOnc+zYMeFBNzY2MnLkSP7nf/6Hy5cvExISQkVFBU5OTsTGxjJ58mSmTZuGvb09+fn5lJaWMnv2bKKiosjPz6e9vZ2YmBhOnTrF2bNnhTm0Z88eKUVVNaJ62UoL7+GHH8bf31/KZeVG19nZKb3VsLAwbty4IS2ktrY2wsLC8PHxkcxPDSRVouLg4MC5c+doa2tj9OjRrFq1itzcXJlim81mvL29Rc5LVUw1NTUi+aam7EVFRTzzzDO/3cD3xhtvvBwYGCi9uuDgYGpqagTJrhr9Sp9O0ewUQh0GSo+enh6Zirm4uIhixcGDB5k9ezbPPPMMfX19/P3vf8fOzo6JEycyZswYYmNjueOOO8jPz5fsoa+vTxRNVCn45JNPsn37dvHsUJvi4sWL9Pb2MnHiRCorK8nPzycsLEyoaz09Pdy8eVN6VupPNblT/hM2m43HHnuMwMBA5s+fL5JOKjNUQp4RERGcPXsWPz8/MYuxs7Nj+vTp0rubOnUqw4YN48yZM6xevZr09HS+/vprUY5WLldpaWnSlzKbzVy9ehVnZ2e8vb0JDAwU+lpRURG7d+/m4sWLEhyVWICSd/f39xeXtY6ODtrb28nIyODgwYPSe1XTwLy8PN555x3J1FSQVQMlFfAUml/R+CwWC8ePH5dnroYInZ2djB49WuANI0aMYM+ePdx11108/PDDwuBQTBel/9bR0SGuYoolAHD33XdjsVjo6urCarWKLUB9fT0tLS20t7czevRoTpw4gUajYfr06dx66624urpKcGtubiY1NZWQkBAZXvj5+YmgrI+PDzk5OWzZskVeS4lJqKAQGxuLm5sbL7zwAs7OzmzcuJH8/Hy8vb3F4AgGQMTHjx/H2dkZOzs7Tp48KXTDU6dOATBjxgz27dtHTEwM5eXlFBQUCEylt7eXjIwMXn75ZWpra+VwiouL4/Tp0/j7+wvutK+vT1RdVA/29OnT+Pj4iEK0EjcICgrC09OTnp4eWSeRkZFMmjSJiIgIEawICQkhNDSUW265hWHDhonikmJk6HQ69u7di4+PD7W1tZSVleHh4UFERAT+/v7SRtLr9Rw5coRz585x/fr1X9Xj+4+YGxqNZhnwR6AfKAUWAoHALsAHOAP8vr+/v1uj0WiBT4A7gEbg4f7+/qv/2+9XGY+7u7ug2BW/1dPTk6qqKioqKsSzVEEvPD09RZBAje4tFgvu7u7i8q5oN+vXryc9PV0WSWRkJLt27ZKpmgIXKz6oQrUrJzUYAIIGBATwyCOP8NprrwljobCwUF7LwcGB8ePHY7Va0el0FBYWCsRGKXgM5quq4cJgMLGaYirIgr+/P/n5+eTn5zN37lwqKipYu3Ythw8fJjc3lzvvvFMm3G1tbbLggSEslpCQEPLz83F3d2f16tUAcg8GZ8uHDh0iNjaW3Nxc4f8qwKga/CgNPYAffvgBR0dHFixYIFzn5ORkTCYThw4dAhAOc2hoKO+//z67du1ix44dhIaGCuC6sbGR4OBgfHx8OHv2rDBdEhMTxRSnrKwM+IXZopSPFQNDp9ORnp4uXOznn3+e1tZWjEajIP6Vwoi61wo0GxwcLE397du3o9PpOHv2rGRSAIWFhQB8/PHHwAAv2WAwcPVn+1E3NzeBeyxatIjDhw+Tn59PSEiIgMrVPWloaECn0xEfH8+hQ4eIiIgQ7i4gPF+tVstbb71FfHy8qEbDANh8+vTp0sP08PCgra0No9HI4sWLgQEu+o4dOwgJCSE3N5e5c+eyfv16fH19+frrr3nzzTeZNWsWNptN1ooCkKemptLd3c38+fMxGo0sW7aMvLw8GhoamDVrlqw3gFdffXVIm8lsNuPh4TFESVypYCv2iKOjI1arVUrf+vp63N3dOXr0KOnp6eJ9o55rYmIieXl5ooEJAxmgTqcjMjKS1NRUgoODqa+vR6fTceHChV+NOf9n4NNoNMHAU4Cuv7//pkaj+RyYA0wH1vX39+/SaDSbgceATT//2dzf3x+l0WjmAG8CD/9frxMaGgogrlSK1qMkugMCAmRhqoWrCNiAUJ6U8YzaEDDQY8vNzSUjI4NDhw6xZMkSIT4rVVmF0Fc6Y+oBdnV14eTkJIsK4J577uG5557jwoULwvNNS0sjJCQEg8EgVC2j0SjgWPU+AHnPyn9XmY93d3eTlZXFli1bOHz4MCtXrmTLli20traSkZExhBCelZVFV1cXH3/8MTabTbiuWq2WgwcPotPpMBqNTJ8+HUC05ubMmQMMBAQ3Nzd5/ydPnuTGjRuiP9fd3c3cuXOFZaAQ8x4eHtTU1AAD/dj6+npee+01AVlnZ2cP+Teqj1dSUoKvry+zZs1iz549FBcXk5SURH5+Prm5uTz44IM4OTmJ0Kg6SEJCQtDr9RgMhn8Jeur5uru7y8/v3r0bgH379pGTkyOBrr6+XmhfSsJcq9Xi7++PzWYTIn5SUpLgxXQ6Hbfffjvd3d3ExsZK5qTValmyZAnZ2dlUVVXx0ksvsW3bNlavXk1aWhqFhYWsW7eOnp4eDAYDaWlpso4iIiI4cOCAZIJr164VShkgTBybbUCJPDQ0lLKyMtauXStK3R4eHnz33Xf4+fnR1NTEzp07BQ2h1+spKyvj66+/ZtGiRRgMBllv7e3trF27Vvqx27dv5+2335ZWkOoBJicnC6MkPT1d+tXqPcbGxpKXlydrduHChcTGxtLd3S10QpttQKJ++fLl6PV6UQ7aunUrycnJIqwBSOLi5OQkScSpU6fk9RQrR92T9PR0vvvuO3Q6nQgxqDWSn5+PzWbDYDD8r9Lz/yllzR5w1mg09oALcB2YAuz5+fvbgAd+/u/7f/5/fv7+VI1qav3K5ezsjK+vr0T8weocTk5OwjEdzNdV3EdFqQGELqSCjYeHB46OjrS1tVFfX8+bb74pmYCbmxsZGRmkpqYSGRlJYWGh9BSjoqLktVWwc3d3Z/PmzaSmprJhwwYuXLiA2WwmJyeH22+/XcjTapEEBwczb948/P39hUYz2ItDZYHu7u6SCTg6OmIwGORn4uPjxUpRcY7Vpm1oaCAqKoqNGzdiNBp59tlnKSgooLi4mPz8fPbs2cPmzZt5/vnn2bVrFzdu3GDfvn1cvXqV7OxsYmNj8fT05IcffqCurk5OUSUPHx8fLxQp9TyMRiNtbW2MGjVKpN2Dg4OJi4tjw4YNkg2qf6sUit9++20efPBBLly4IIMWs9lMQUEBOp1OJnMqECmqlqOjI6mpqTg5OQmbQ/V1B68RrVbLrFmzqKioYNu2baxatYrNmzfLtK++vl76UQkJCUMa6vHx8bz99tsC7jUYDKJEbbFYMJvN5OXlERUVJZQyGFDq2bJlCwcOHGDu3Lls2rRJskfFxMnLy2P58uUkJyfLvw0JCREOq8peFKtlsNyaeo9KbHTZsmWyftra2mhsbCQ+Pp62tjYSExP57LPP5LBTawQGMn4fH58h3iq5ubnMmjWL0aNHs2LFChYuXCjKNVu3bhUOempqKkajEavViq+vryinKGWapKQkZs2aRUxMDBkZGSQmJgIDdEWLxSKqR8oXxdfXl8jISOmDqsTixo0bwtp59tlnhdfr4OCAu7s7ycnJkuEp3USAs2fPDjELUzxudalK8t9d/5EslUajeRpYA9wEDgFPAwX9/f1RP38/FPimv79/jEajOQ/c29/fX/3z90xAYn9/f8M//c7HgccBgoKC7hgcFAZfV69eFfKz0WiUIKhO78zMTA4cOCCbV/H4Wltbh2jhRUZG0traSkpKipR5MFAKtLW1MXPmTLZt28aWLVsIDg6W8f9gIOngMlZRj9ra2khJSSExMVF4nEajka6uLs6ePStllJL0gV+ENZUJDvwSrJVi7nfffce+ffvYvXs306ZNE2BqcXExra2tNDY2yikHA/zgefPmYbVaKSwsFC5ke3s769evJzIykqeffpoDBw7IAeLm5ibyQtXV1fj7+2MymeT0Bli7di3nzp1Dq9WydetW6uvrsVgsJCYmUlJSwubNm3n11VfZtGmTyF3NnTuX5ORkcnNzOXDgAO7u7mzZsoVly5aJkrCDgwOnTp3i6aefZsuWLcBABpmYmCjad56enkRGRorckMlkor29naCgIAH/2mw2MjMz6erqoqCggOeee45Dhw7h7++PwWAQEYXU1FT0er0A0NUz1ul0HD16VNbKtGnT5J7q9Xr5nlarFen64uJiIdCrf6e45J6enpLdZGRk0NraSlpaGr6+vuzcuROLxUJERIS0V9ra2ti/f79wYE0m0xD+tE6nw2Aw0NXVRV5enohNqINKp9OJ6opyq1MH+Lp16wBYtWqV3K8VK1bw9ddfU1VVRUpKCjt27MDT0xMfHx+ioqJYv349aWlpcui1t7cPcbZTPHmFxWxra2PJkiVs2LBBeNsXL14kLy+Pt95661/2obu7O5mZmezYsUO4tupSXF/FZc/IyJDPb7Va0ev1JCUlUVBQwN69e+nq6iIpKYnIyEjKysrkMys+dmlpKU1NTf826fpPSl0vBrK4W4AWYDdw7//17/6vq7+//wPgA4CRI0f2nz59WnxvB1/h4eHMmjWLoKAgYIBD2N3dTUFBAUajkby8PDH9VgtUZR4qmAxeHCUlJUN+/9SpU9mwYQPZ2dksXbpUUnAV8JS2nc024OGh9L48PT3l4dtsNsxmM2VlZdID0Wq1REZGSnnu5OQkmd0/X6qfCQMOXu3t7eK6lpCQwN69e+WzqWmhggPo9XoxrH711Vfx8fEhICCA/Px8tFotCxcuFJe53NxcUcRIS0sjMjKSvLw8KioqhvSzHB0dycjIoKSkhIMHDxIZGYnBYODatWt4enqKCMP+/ftFuaWmpkbksSIjI8nNzUWv19Pd3c2iRYtEtFWr1VJfX09KSgoBAQEy6VTPavny5RQXFxMVFYWjoyPFxcVC3RssSqBI/woEGxwcTFJSEjt37iQ+Pl5K/+TkZABpKah+pXIAq6ioEJzili1b2LZtm7QAtm/fjr+/v/y+4uJi5s+fDwzwqRXZXvWB1SGnRCMUs2Pr1q3MmjWLxYsXiz6i8rFVB7VaJ2qNqExQ9dpUlqOCglarFY1Ak8mEo6MjM2bMkHtx6NAhTp8+zbhx4+RALCgoYPny5YwcOZL6+nqqq6vx9PSkurqaiIgIqqurpYUDA/3M1tZWGhoaOHv2rDz/lJQUuru7KS4uZuXKlezbt48dO3bIuoeBQ2Px4sXs3LlT5LtUpl5YWCitLZ1OR0ZGhiQBqtRWisxqPR06dEg0C9V+VtqKERERREREEB8fz+HDh9mwYQMmk4mnnnrq3+43+M+GG/cAV/r7+60AGo3mC2ACMFyj0dj39/f3ACGAStksQChQ/XNp7MnAkONXr87OTpHDCQkJoaSkRCwdFyxYIEEPflEymT59uoz3q6urKS4uFjcpdanyaTAFqLW1laysLHQ6HV1dXRiNRgICAti0aRMffvihIODVpYQTB6fQajNGRkZy7do1cnJySEpKkhOrvb0do9FIRUWFlExdXV1DhEjVpQLa4AzS0dGRxx9/nK+//lqyAvV9i8Ui70kJiKpFVF9fL0MCvV4vmaYK0OvWrROoQGFhodyXGzduMHr0aPEqhYGe6bhx49i1axdtbW2UlJRgNpv54IMP2LNnDykpKSIE8fbbb7N8+XLGjx9PcnIyJaEkr+IAACAASURBVCUlUiItX76cDRs2iDDnyZMnpeycO3cuf/jDH6TMiYyM5Pnnn2f27NmiI/fTTz9RUVExJDNQ901damO1traK0ojNZpPh0mClDlX2tre3U1JSwuLFi3nvvfdITk7mtddew8nJidDQUOlhqYGaxWJBp9OJYOfixYvx8/Nj06ZNcphaLBYiIyPx8fGRg1ENxI4ePSrG5qpcVHRAlcEptoZaq6qvZrPZSElJ4fTp0zg6OoqqiSrnFy5cyPr16yVLmzhxomRf69atY8aMGdJjVdWDm5sbZWVlEmQ2bdok1gmq1FWVgbr3ZWVlaLUDVo+5ubmiVjNr1iyWLl0qgx97e3teffVV0tPTSU5OxsnJCXd3d9kjg9WI1NXT00N9fT1BQUGCLYWBUl/dt8HSZFarlWvXrrFkyZIhijxdXV00NjYSEREhiI9/d/2fpa5Go0kEtgDjGCh1PwaKgGRg76Dhxrn+/v6NGo3mT8Bt/f39i38ebjzY39//0P/2Gi4uLv1BQUFyWuh0OpnMJCUlyYNWNx34l5uXnZ0tvRLVIFVBpaGhQSSBBmOGFKn+ww8/pLi4GEBKUoXdU5NIX19f9Ho9ZrNZGtVdXV00NDRQUVFBe3s7qampZGdns2LFCsHTqSxKbQIl2aNESwf7wg6eRgNSch0+fJiTJ09KAANEzfexxx5j48aNhIaG0traKqWhMqlWJY5Op8Pd3Z20tDTy8vLYuXMnTz/9tNDFJk+ezKJFi4CBSa9SEVbZmtFoJCsri4kTJ7Jq1SqZsqelpUmboKCggJSUFBnqvPTSS5w+fRqr1UpxcTHTpk1j3bp1/Pd//ze7d+9m6dKlJCYmkpycTHZ2tixqVX7V19dL6ac4tUrhZnCfDxjiU+vk5MTdd9+N2WymsLCQkJAQUbtesGABWq1WgoqaciqNu4aGBo4ePUp7e7vo67m7u6PX6/H09OTo0aNotVoyMzPJz8/H19d3iFew2WzGYrHg4eEhz1H1o5OTk7FYLOJtXFVVJTg3lYmr/1eXj48PCQkJ+Pn5sWDBAgA2bNgAIHCmkJAQGhoaiI+PZ+fOnSQmJjJnzhxee+01Tp06RWtrK5mZmRIYlV+H0Whk3rx5bN68WV6zqqqKrKwssadU7z8+Pl7EYwGhMiqNQ6PRSGJiIlrtgH6gMsNSVYV63djYWNrb2zGZTGJVqfpzg/uaqh+rBAoMBoMMX1RGrpKdiIgI2Ruq39/a2kpxcTHt7e3/ttT9T3t8rzAwme0BDAxAW4IZgLN4//x38/v7+20ajcYJ+BTQA03AnP7+fvP/9vudnJz6U1JSaG1tFYyauqlLly6VDDAhIYHU1FSxtVN1v729Pfv27ePQoUMSEBTZWlHF1ARVq9WK/VxkZKSk0appqvwHVEmmemHKWrC+vl74rnV1dTQ2NkoAhIG0fPHixRQUFPD++++LX0ZCQgL5+fky6VS6c2pTuLu7y4NX7zkyMpKPP/6YjRs38uOPP8p7am9v5/bbb2fatGns3LmT6urqIYFeUbbU4oyPj5ehhbu7O+np6UMOjnfeeUf6hSaTCU9PzyGNbRXMlixZwuzZs4mNjZWsNSEhYYhenTJ+Vk38zz77TMovJycn9u7dyyOPPCLS+f98NTU1sXHjRrq7uwXEroj9gwPJ4ExY3TubzSZloFKraW9vZ+7cuQLjOXTo0JBM6i9/+QuPP/64CNCqjVNcXIzFYsFqtRIbG0toaOiQSbUKhqo3rQZP6oA0Go2YzWaMRiMLFy6ksLBQ1snChQspLi4mICBADqnk5GQKCwuln6fWklarJSUlhTlz5nDw4EEKCgrIyMgQT9uenh7Wr1/P8uXLuXTpEjk5ObS1tTFv3jx2796N2WwW1zO9Xi97xmq1smPHDjkUVRBUk/vU1FRyc3Ml2MIAEsDR0ZHVq1dLGQ2IEVBycjLV1dXk5uYCCFJCwcR27twpE3QYOKx0Oh2hoaFSJaj+p8qKFUoiNDSUkJAQMUu3Wq2YzWZR5FEJkdFolOShqqoKi8Xy/z3w/f99OTs798+cOZOffvqJqqqqISfepEmTZCFkZGSg1WqZOnWq4JO6uroICAggIiICq9VKRUUFN27cQKvVUlFRIU36f1Y/Vqe+wWCQzRIREcFPP/0kP6MekLJIdHBwGNKEVld9fT1ms1mmosHBwaSmpophz4svvoi/vz8hISHShAeGvDeVmQ1+j76+vqSkpBAZGcnevXvF46ChoUEsB5U/qrpnvr6+XLlyRUqY4OBgTp48SVRUFHl5eXh6ejJr1izy8vJIS0uTjNjX15fCwkLq6+uJiIjAbDaTmZkpUlvLly9n9uzZ0jPLyMjgvffeY926dWRnZzNv3jz27t1LYmIiaWlpvPjii8Av5V9qaiptbW3MmTNnyKYZfKmNqwK34kLbbLYhkkaqH6QCl8ViEYVetZHVMx2cmaseXFtbmzTFFfxh8eLFPPXUU+KpMnLkSEwmEwaDgYyMDPbs2SPPBH7B4NXX11NQUEBUVBTu7u6YzWaZmCs5p4iICLq7uyWzUeKfjo6O+Pn5ieirgmyoEvOLL77A3t5eMvCCggJp5KsEQAHM9+7dS2RkJHv27CE9PZ1Zs2bh5OTE8uXL8fT0lOfi6OjIZ599xsmTJ2loaODZZ58FEOznrl27JFCq9wMDZe7cuXOJi4sT/KjCxba1tUn7Q5XgqampHDhwgIiICLKysjCZTGzatEkwuF1dXQQHBzN+/HhaW1s5e/Ys7u7uMiBKS0vjpZdekoGKh4cHOTk50ucGBKqjPE0UjKWmpkb2SV1d3W/bc0P5qsbExIhkkaJ3KdpMYGAgMTEx+Pr6cvHiRXbs2CEI7UuXLgnLYbCIpXJlGyxbpZgYypth//79WK1W8Z5wdnYWr4/BlDI7OzsBq6qft7e3JyAgQIRAf/e73/HEE09w9uxZLl26RExMDKGhoaxdu5aqqiqam5tpamoSep7i7gLyeori5uHhQUtLCytXrqSsrIw77riDyMhI7OzsSEhIEJkgZbVpb2+PnZ2dZLJNTU3CwFDqxwqaMH36dIqKiujs7CQ/P5+LFy9iNBq5fPmy+P3u2LEDvV5PeHg4zzzzDOHh4bi4uAhFMCkpiYCAAIYNGybcWUVtUsKW9vb24tTm7e0t7IXBfU51vfPOO/JZdDodZWVlcq/++T7ZbDamTJnC5s2bmTJlCh988AFubm60t7czffp04Qq7ublx+vRpRo8ezblz5wSrZ7MNEOgzMzPFMF1ZLVZVVeHj48PMmTOxs7PjyJEjuLu74+fnR0VFBXFxcXh7e9Pa2kpMTAz3338/77//vri3tbe3y2FdW1vLyJEjxeEsLi6O2tpaUWfp7u4WnwmlN6naMIWFheLsZzKZKC8vp7e3lytXrogP8PHjx0UQIzExkQkTJmCz2cR5r66uTiBbBQUFnDlzhpMnT+Lp6UlYWJgoF3/88cdUVFSQl5dHX1+ftDYSEhI4e/YsWVlZhIeHc/XqVc6cOYOLiwtnzpzh9OnTnDhxAn9/f5qbm7l+/bowK9QARVVivr6+eHl5yZqMjIxkxYoVbNiwAZvNJlzoH374gUuXLuHi4kJfXx+33XYbu3btIjw8nL6+PuE6K13J7u5uYcyMGzdOxFEvXLjw2xYpWLly5cu+vr6iaqKwbzCgWuHu7i7KHAqAe+LECdG+A0T91c/Pj2HDhqHRaBg+fDjNzc3/8nqD8T2HDx/G2dmZyZMny+ZRDu3qUqee1WoVQQNFW+rv72fZsmWsWbOG2267jW+++YavvvqKJ598kvT0dEJDQzl69Khoi9nb29PQ0CAbQwVkleWpYKgoYXZ2dsybN4/c3FzOnz9PQkICN2/eJDMzk7CwMFxdXXF2dqa3t1cI+8pIx2Qy4e/vT1hYGHv37uXMmTOiVLts2TL+/Oc/i+qyKmmnTZtGXl4eS5YswcHBgdmzZ/PVV19RXl5OSkoKBoNBxFnDw8Opq6sTl7hly5bx17/+VaSKoqOjefLJJ4mMjCQnJ4clS5bQ1NQkeMvB17lz57h06RL9/f1Mnz6dnJwcIiMjqayslHukvrq7u7n33nslkzty5Ajvv/8+EyZMYM2aNcTExHDmzBmhjUVFRQlNMDo6mpaWFkJDQ8nMzOSbb74RDJ9qpAPExcWJic6jjz6KXq/n+vXrACIaMHz4cEpLS4W1YTKZsLOzkzUJv7AgysvL5SssLAxAsllfX1/6+vqElaS4roP9YHJzcwkNDeXKlSsiOuDh4UFUVBTLly8XxMHVq1clcSgpKZHgDwOMkaKiIq5evUpZWRlZWVns2LEDe3t7Zs6cSXR0NBkZGRw9epTnn3+ey5cvs2bNGqKjozlz5gy7d+8W7+XBMlk5OTnU19cTHh6Os7MzmZmZHD9+HG9vbzIzM0UOraamhttvv52UlBTKy8t55ZVXyMzMxNnZWehq58+f58477xQxBXVgl5SUUFdXR2Jioqzr/v5+goODuXbtmhg6KbMqi8XC1atXf1WW6jdR6vr4+PQrKWpVxytMmbu7uwAeYcArQa/Xs2nTJsxmM/X19UOEHZ999lnB9Kh+gqr5B/eJxo8fj06nY9GiRdy4cYOVK1fKSagGE6p/p3BVMNDUVY3r5557jpiYGJYtWybpdnZ2Nvb29rzzzjtSqqlSQzXnFegSGAIBgIEBh7+/vwxDtFotCQkJrFu3jtGjRwMM6Vvq9XqZHKoBjSqd1LDD39+frVu34ujoSHp6OtnZ2axfv176eaqxbzKZWLt2LVlZWWRnZzNu3Diys7OxWCw8/fTTrF69muDgYCZPniyDGr1eT05ODiEhIUL1UlAUdc2fP19UY4B/gSwNLnHd3d2xWq3CYFGg6cF2nYPvlSrz1YDA39+fp59+msTERNavX8+PP/4oSh+qjFR9OQWGH0xfa2tr47/+679wcnKSfllSUhLZ2dmYTCY2b94sk2FVdplMJmljqOGXxWIRzKF6zooVMn78eLq6uiTzVXAnVY4DMuVWk2rVC1T/bTab5X0rdotCRMDAkEL1XRXQfN68ebz11lvy+++8806cnJxISUkRf5i8vDyBqgxuOY0fP56TJ08KNlSt561btwIwa9Ys9u/fz9mzZ4VepgZDat8ogyWdTsemTZu4ceMGK1asICEhQeBACt6jIGkK9qM+gyrXx48fL3i9vLw8DAYDubm5RERECFLh2LFjv4rj+01kfC+//PLL9vb2eHl5iVKHzTYgUdPS0oKrqyv9/f1y0uj1eoqKikTaRwE5N2zYIBJAKvqrS/XQ7OzsuHnzJq2traxbt45hw4ZRU1PDzp07pTS02Wzi5eDq6sqaNWuIi4tjwYIF3HfffWRnZ3Po0CHy8vJoaWnhueeeY8yYMfzjH/9g69atfPzxx4Ib02g0Qx7oiBEjsFqthIeHiyadskxU9pBWq1XKVhhonP/xj39k1KhRlJeXi3mzRqPh+vXrIgE0ZswYCgsLue+++3jggQcEllFSUsK9995LWFgYS5YsEZqeslLs6ekhMDCQRYsW8corr7Bhwwbef/999u/fzwMPPEB+fj5FRUVoNBoWLFjApUuXSEpKYtKkSQwfPpzExERiY2P59NNP6ezsJDs7m1OnTqHT6fD29ubo0aMkJydz+fLlIeZOMGD6dPz4cbF+LC0tZdu2bRw5coQXX3yRXbt2ybNUisYuLi44OjrS0tKCi4sLM2bMICYmhpKSEuLj43FycuL5558nISGBCRMm4OfnJ1jIhoYGgoKCaGpqory8nP7+fskkH3roIVH3LS8vZ9SoUXR3d1NYWIidnR2urq6cPn1ahkOPPvooSUlJGAwGbDYbP/zwA/fffz9OTk5oNBrCwsKEU97Z2Sm82wkTJkiQPXv2rAhjuLq6SmslLi6Ompoa7O3tSUtLw2w24+joyOHDh4X5oqapSnxWBYuFCxfyj3/8g5aWFioqKhg5cqQorKSkpNDb28utt94KQHl5ufBhCwsLMRqNHDp0iJs3b8o9b25uprq6Gr1ej4eHB15eXjz88MP8/e9/x2q1MmLECFHeDgwMpLe3l0WLFmG1WiUTVNXOiBEjePPNN7l8+TKhoaFcvHgRm80m9g1arRa9Xs/x48cxGo0iD2dnZ0d7eztms5na2lr27t3LgQMHyMvLkzaYRqPBYDAI//vcuXO/qsD8m3BZs7e354svvpC+lsI0KSUHNW1LTk4WelhXVxdPPPEEGRkZ5OXlkZGRwVNPPSXSR1lZWbi5uUnWNBgvp2SFFEBy+/btYheosgJAAKQwcKoq0O7WrVtZuXIlWVlZwtxYsGABXV1d0teoqqri0KFDVFRUyII/evQohYWFzJs3D5vNJvxKNZ0cnFmqaa86dWfPns3UqVNF5URlMA0NDbS3t8uARTWac3NzqaqqYs2aNXz88ccCB1Kf18/PTwDNZrOZjRs34ujoyNq1a/nwww/FSvG9996TrPLtt99m5syZrF69WsDKNTU1HDt2jIMHD1JWVoa/vz85OTn4+vqyfv16CgsLhfEQFxc35LlfunRJsHLp6emYTCaeffZZqqurZZqoqH2Dsw/VBlEZp8FgYM+ePdI43759O9u2bePkyZPs3LmT/Px8li5dKhhNBdj28PCQwzErK4sff/yRtLQ0fvzxR7q6uqSPFBwcTF5eHnv37iUrK4sbN25IJRAXFyelV3JyMnv37sXJyYnExETh/7q5uXH77bfLUENlhQaDQTjnapo8eEg1cuRIwdW5u7sL2kFl8CorDAkJEZaD8i9RmXJUVBSNjY0YDAYKCwvFyPzGjRtYLBYZbFVUVAwRzxi8DtVn3bp1q/DWFZC/qqpKnPOUt01VVRUrVqxg8eLFAi+DAfvSpUuXkpOTw/79+1m1ahVarZaMjAySk5Ox2WyEhISwevVqqqurpfRXwiHqWVksFsmU8/Pz2bJlC3l5edI6UO9n2LBfD2+/iYzv9ddff/nixYv09PRIX2uwQKiPj480q61WKydOnGD16tUC7Pz888/ZsmULTz75JLGxsUyaNInw8HC+//57IdSr5r+6FixYwB133AHAypUrBQenTl01NRw1apS4mbW3t6PRaJgyZYp4w3p7e5OXlyfZiL+/P97e3nh7e7Nz505WrFjBrbfeSlxcHFlZWTKK9/b2ZvTo0XzzzTdD+JlKZw6Qhq+LiwtWqxVnZ2deffVVPv30U8xmM66uriJJNXr0aEwmEz4+PowfP55r167h7e3N+vXrqaioYMSIEUyaNElKpoKCAkpLS3FwcKCrq4uDBw/i6enJ6dOn+eSTT3jggQfYt2+fnPDvvvuuCBocPnxYJutvvvkmMTEx5Ofn88EHH7Bz5078/PxEQ7CmpoY//OEPwAD9cPjw4Vy6dIkrV66Ql5fHzJkzmThxIt7e3hw/fpypU6eKGC0g/sXKaU0dXnfeeScK+2kymXBxcZGekKurq1hWKjVoi8VCVFQUixYt4tq1a1ISRkZGkpCQIIZB+/fvp6+vT7CVSpfRx8cHX19f0fQLDAwkOjpaps+enp7U1tYSHR0tDnANDQ3o9XrxVrl58yaFhYUiZ6Z6xklJSdTU1IiMmuI/+/n5SfDr7u4Wx8Camhq++OILHB0dRafOZrNx/vx5wsLCGDVqlLRZmpqaCA4Oxs/PDxcXF65cucKiRYvYtm0b58+fF3D6iBEjmDp1Knl5ecTFxTF27FjJtG22Ab+Y2tpaioqKGDduHCtWrKCkpIQHHngAb29vkft3dHTkiSee4OTJk3R0dBAXF4e9vT1TpkzB1dWV1NRUVq5cKcZe7e3tXL9+XcR2X3/9derq6mRAo+5ldHQ0HR0dPPnkk2i1AwZOyltG6UUqH5ja2lr5+jVZqt9Ej8/T07NfEa7/GdyrLsWe2LJli2CX1PQSGILgVmoZarKkwI0qU9D+v/bOPSqq89z/n63AIFcRRoMMUYFIHQ23RMVo1BjBxoOmHjUrQhorqTmak4s9iZdzRNsYmqXGVqtpNFrx0ESqFWMiiEGjBkIiBA1eh0gEkZso9+Eiw8X5/TG8TzBNzu/XnvUruMKzFsuZPbOcd7977/d9Lt/n+9XpuHz5MrW1tVRVVfGv//qvAk3oDqQEG05NQWXy8/NxdXVlwoQJQm2uSusKia/aaVJTU+8SWPby8mLevHkkJyeLZzdq1ChJEiuvtLuX1x2bpt5nZGSQlZXFv/3bv+Hq6kp5eTmPPvoon332mXDIdddpVS1CXl5eAoFRaHyFf/P395dEt8lkYvv27cyePRuj0cjp06cFg6d6ar9riYmJtLW14efnR15eHu7u7ixYsIA1a9ZIv2hxcTEODg6iQrdt2zbBqalFVDW1f9dU65vK5YENYmQ0GklJScHHx0dyWV5eXvj6+kp7U3V1tQDbFfA8KipKmHRU9DBhwgQyMzMlwgCESUXhzZTmiXo/depUJk2axKpVq8TTyMnJkW6FsrIygoODaWpqIj09XXK8H3zwAXv37hUxd9U6V1Nja3BqbW0lNjZW2hKVVGZmZiYNDQ2ysdXU1Eg+WnUSrVixgtbWVuLi4iSfrLp41AJRXV3NqFGjBB6i8umTJ08WaInStHVwcBAAsYrGVM7U3d2d5ORkfvGLXwiWTqezUVJ99dVXkpNU44iMjOTw4cMCcVKhrerq6T73qkNJ5efz8/NxdHRkxIgR8ix0rR13YQNjYmIwGAwcPnyYjz/+uHfn+N59993fqBVdVR3NZjNDhw6VxPagQYNwc3Pj9OnTfPnll9TX11NeXs6VK1d4+umnKS8vJygoiOrqah577DGampoYNmwYdXV1NDY20tzcLLABJycnlixZwoABA1i6dClWqxVnZ2ecnZ3vah1SLLLXr1+npaWFCxcuSKh5/PhxioqK6OjoIDAwUG5GvV6PnZ0dEydOFOB1RUUFrq6ujBs3jtzcXNFcUCSelZWVd8E1Wlpa7sr9Ke/32Wef5be//a10XyixGkV9P3DgQGpra3FycsLDw0P0crvL77W3t0sV2dvbm2effZb58+fz3HPPMXXqVD788EMuXLhAYmIi165dE8p9d3d3pk+fftd1S0xMpKmpiTNnzggCPygoCH9/fwICAvjpT79t6S4pKZGiR1paGpMmTSI9PZ2ysjJqamqEPusH7g/69+8vzNXOzs7MnTuXY8eO0dnZyZNPPsmlS5fEQ46NjcXd3Z2cnBzs7OwkjFR9yApuMnbsWGJjY0lLSxPlt8DAQLZt28bZs2cZO3YsGRkZVFZWyoai0+nw8PBg/vz5gE23WW2oBoNBlMWUDOWdO3eYPHky9vb2lJWV8fzzz9O/f38CAwNxd3fHycmJyspKNE0TL9PZ2VnwrGoRefzxx5k2bRpubm7cuHFDrp+iYRswYADV1dVkZ2eLsJZqD1M6ygUFBeLtq2fs5s2bODg4CBTpmWee4fjx43R0dMh4bt68SVhYmNDXZ2VlYW9vz6uvvipYWSXKpOQ9hw0bRnNzs0QeEydORKfTcf78eYYNGyaIBL1eT1NTE4GBgaxevZrf//73ogoYEBCA0WjEyclJnAPFdai86CFDhkjU4+vry6xZs3B2diYsLIxjx479IPX8/xMR6f9vs7e3x8vLi/Hjx9+lzK5Aj6pVRuV7bt26JUj7wsJC4uPjMZlMxMXFER4eLjmCPXv2EBoaKjeAAjarjoYrV65w9epVBg8efBcoFpBqbE5OjnhJs2bN4uDBg7K7WCwWDhw4wPz58zGZTBgMBsaPHy+UTfHx8bJTHj9+nA0bNkgeRVH7qPOCu+m01DhUxVoBn8ePH4/ZbCYjI4PRo0fj5+cnuTpF+AjfNrNnZmZK37MKo2pqarh165YUeA4dOsSbb77Jhg0bpONh/vz5xMfHU1payrp160hMTJQF5dixY8KeoeiWVB7q3Llz6HQ6tm3bJhRgaWlpzJw5k9raWlJSUtDr9SQnJwsHm6rO/ZApTwkQMKsqFrm7u3Pw4MG7OnMULk91ArW3t4sHo0gtXnjhBVavXk1mZiazZ8/m7bffprCwkOeff57Jkyezbt06oqOjsVgsTJ06VarkCnyuCjdgI7ZVG7WqjhqNRmFL+fTTT/H39xc1tJdffhl/f39hoHF3d6ekpEQ8UovFwty5c4WNRt1ru3fvFskEvV7Pli1bJCpob28HbJ6Soo/qXuVV40lOTmbq1Kmkp6cTExMjleuKigq5/0JDQyktLaW0tJTCwkJmzZqFg4MDSUlJLFmyhE2bNlFYWMiWLVsICwsTerPTp08TEREh96iCuxgMBgwGg3iw5eXlhIWFUVhYyN69e/Hz85M85MqVK1m+fDkWi4Vx48bJMxsaGipRn+qYUc+O+o5CFiiqsO/DiirrFR7fH//4x9+4urqSkZHBmTNnyMnJITMzk/vuu49ly5bx7LPPMmfOHGE4mTRpkjQ1DxgwgJKSEnx9ffnpT3/K2bNnpeqm2C7Gjh0rO2NgYCBz587lgQceYOnSpTQ3N2M2m0X7FGxhq6enJ62trVRWVuLl5SX07ApPqLRgo6OjZce5fv06BQUFHD9+nOzsbKmCXbx4kXXr1tHW1ib4I71eT319PbNmzaKyspKqqio0TRMAr1r4lIeqeiCPHj1KXV0dUVFR/Pu//zuJiYl4e3tz/fp1XF1dCQgIwM7OjsLCQpqbm6murmbatGlSjFB0+jt37pTuiq+//poTJ05QVlbGhg0bhO3lySefZPbs2YLfO3v2LLdu3RJR7zlz5tDZ2ck333wjwNG6ujoOHTqExWLB09NTNCGysrLIzc0VKn+Fx3NycvpBb2/Xrl089NBDQpQwefJkOjs7BaqkPFqlt6vGpXKoFotNs2PgwIEAXL58maCgIFatWsV//Md/UF1dzc6dO7l9+za/+93vMBgMvPrqqzg7OxMVFcXRo0d59913qa2tRaezabtUVVUxceJEWlpaGDVqFLW1tRw9ehRvb29cXFxE2jMvL4/3j1+sAgAAIABJREFU3nuPHTt2UFdXx7BhwwTSoUJ+FWFUVFTQ1NSEpmm0trZSW1tLdna24AgVxEnlSM1mM9evXyc0NFR0gJVKn52dHU1NTXR0dEilVOUez549yxNPPCGEIGfPnuXZZ58lMzOTGzdu4OzsTGtrK5s3b+bPf/4zbW1tGAwGFi9eTGhoKJ2dnXz99dfk5uaSmppKQEAAjY2N3Llzh6+//lryeYMHD5YFWAkZqULFtGnTmDJlCrt27eLMmTMEBAQQGBhIXl4eLS0tVFZWYjAYqK2tZcyYMbS0tHDr1i28vb0JDQ0lOzub4uJifHx8uHPnjggyNTY2cuHCBT766CNu3LiB0Wjk6NGjvPLKK723qltZWSmtMyrfoDBTL7/8MuvWrWPv3r0sXryYrVu3EhoaKqu52Wxm3Lhx0qun+PoMBgM+Pj4kJSURHh4uDBFlZWXyoCk2Z0VyCbaddfDgwbL7Ojg4SOO4YnJxd3cnKytLmFeUB6hyTWVlZVRUVPDyyy9jsVgkh5acnMytW7e4//77eeyxx1i0aJH0fsK3fGQ+Pj4CqlUVLbDt5suWLcPR0ZHY2FgAoqOjyc7OlodJVZFVu5oimZw7dy6hoaHodDoSExMZO3Ys0dHR5ObmCpPtkCFDSEhIIDw8nAMHDhAREUF4eLjkBFUOJy8vj507dzJnzhxOnz4N2HpbFUuzu7s7W7duJSQkhLS0NKqrqykpKRFRJ5WzCgkJwWg0Cr7vu6YwlopGfPv27Rw4cIAjR45w5MgR5s6dS25uLvHx8eTk5LBmzRohK1CVeUdHR8mjtre3S+udErdOTEyUHm3FdqLX68Wzy8vLY+3atSQkJLB9+3ays7OJi4uTMao2tB07dpCdnS3N92azmUcffRQ/Pz+mTJlCeXk577zzjlBBqdzj95liuVbzqarAKqdXXl5OZmYmx44dw2g0snXrVsERAlKxVW1wiuLd09OTuXPnAraCXnx8vHhxqp9W5RkVPfxbb73Fxo0bWbhwIRaLhZ07d4p3FhUVRVlZGQcPHryLKMDBwUGo9BU8RgHS4+Li2LhxI0ajkXfffVcYs1XUlZmZibu7OzNmzKChoQFXV1eZv8LCQkwmE+3t7TIXCosaEhJCeHg4wcHB0h7aHQnwXesVxQ0nJyfrv/zLv0iSsnuBwWKxMGPGDHnAVAP90qVLef755yU5n5ycTHZ2NqtWrWL9+vWAjX5cTZYiJ9XpdGzfvp1Dhw6xfPlyCZG609p8t8BhsViEPEHRkdfU1AjVUHl5ufTI/uQnP5GKr8FgwMvLi02bNglXXnt7O8HBwYSFhQnkwNfXl3feeQf4W/hG98Z7i8VCYmIiL730EhaLhcjISNra2nBxcRGiTkXxpHoe4Vuq++7hwK1bt0hISGDVqlVCPHrq1CkCAgKYMmUKu3fvpr29HbPZLIpsCnwaFxcnDeuqN1qNsby8nK1bt/L+++8TFxfHjBkzBLJQWFgowHC1QDk6OgorjDLlfQ8aNIjc3Fy2b99+F8xCAVkVJOX9999nyJAhNDQ0EB0dzdChQ4V6vrGxkcjISE6dOkVSUhLR0dGUl5czZcoU1q5dS3BwMA4ODsTGxkpzvdFoFKr3oUOH0tTURGpqqrS5KU2WhIQE5s+fj729PYBUvW/evCnN9xkZGQJo7l5gUZ4QIOw9KpxWY1BkqUqDQs0zQHJyMpGRkZw7d45x48YxYcIEzGaznLMqtqiNXIX6Cv6j0g2KmOD48eMCzJ41a5acp4KGqA0rPDwcgJdffpk1a9bw0ksvCRohMTGR9evXc//997N+/Xqio6NlIVXXzd3dXYoVqgtDr9dLH35VVRXr1q0TKI7JZBK6tu7FldLSUgGRWywWVqxYwaeffkpNTY1srG+//TbFxcW9t7ixefPm33h6ehIUFMSNGzfE+3r00Ufp7Ozk8uXLIszt4+PDuXPnOHHiBCtXrsRsNnPx4kVJpre1tfHAAw9w5coVUZHy9vamrq4OvV7P2LFjGTNmDGvXrpWw5Pbt2zg4OIiYsZ2dHS4uLtLuY7HYSEibm5vp6OgQ+cpLly7R0tIimMPOzk6qq6vx8PAgLCwMq9UquK0lS5bw4Ycfcv36dR588EE+/vhjHB0dBcx65coVCcfVza3Azwqs7OHhwfXr10lOTmb9+vXcd999eHl5ERsbKwBRe3t7hg0bRn19PdXV1ZIILyoqYvPmzdx33304OTnxxRdfMGLECI4ePUpWVhbTpk0jLi6OF198kRMnTjBw4EDs7e0ZMWIEer0eb29vbt++zYgRI7hz5w5Go5HAwEDa2tpE9Ly5uVmIDYKCgrh9+zbl5eU88cQTVFVViaJcVVUV3t7egne7dOkSTU1NUqncvXs3w4cPZ+DAgXh4ePDXv/4VnU4nvc4KulFeXk5OTg6VlZUSTlVWVvLNN9+Qk5MjY2xtbWXjxo1SfR00aBBms5kdO3YQHh5OZ2cnoaGhbNiwgQULFmA0Gvnss8+orKxk//79BAQEoNfr2b17t4B6AwMDeeSRR3BxcUGB77/55hvReXV0dOTy5cs8+uijLFy4kK+++orbt2/LPaYKEgUFBdx3332iLNbc3MycOXMkHdDS0sKMGTO4ePEizc3NFBUVMXr0aCGnmDZtGqmpqaKZrLR+CwoK0DSNwYMHSwhZUVEhsKCLFy8SGxvLsGHDJOf8zTff0NzcTG5uLps3b2bPnj0UFhbi4eGBi4sLTz31FL/+9a9JSEggLCyM0tJSTp06RV1dHenp6Rw7dgxHR0cRcX/vvfewWCxYrVbc3d1FLU0xtnh4eHD16lVu3rzJ559/Ltdm5syZPP7449Jnr8TuNU2joaFBiqBms5na2lohRt2/fz9tbW1UVFQIsP+H5CV7hcc3fPhwq2qYVsl6pa6mPCClF9DQ0MBzzz3HsWPHWLNmDW5ubhgMBmF+UKX8xMRE2dUUtXZYWBgzZ86kuLiY5cuXYzKZhN8NkFY05R0qIRpFfQMIBfiuXbuEpr07dQ/YPJbW1lby8/PZvn07ra2totmg6LLKy8spKSmhqalJdnmli9D9PXxLw6QYZtauXSswju7tTkqBKzMz865zUi1C8fHxAk3Ytm0bCxYsYMWKFbz00kvk5uaSkpLCuXPnBHrg5uYmO/GOHTs4ffo0/v7+VFdXExERIV5LYWEh586dExW58ePHs2TJEqKjo4mIiBB+tba2NvLz8yWx7+joKIUglX7YtWuXhGOKFmvdunXodDrx8qqqqsjMzMTe3l7gDO7u7qSkpGA0GlmxYgWpqamsX7+epqYmEehRuUHV763swoULAtHYs2cPRqNRii/K+wsPD2fbtm1ClZSSkkJGRgbz58+ntLSU0NBQKSiEhoayZcsWoU167LHHGDVqFMeOHcPBwYHU1FRhXVbsIoqAtLsnXFhYKIW+7nRZRqORZcuWCZuMgiWp35s9ezaNjY0ColdsKP7+/mzdupX4+HhCQkJET0WpoSmOPpPJRFZWFgsWLBAih2XLlhEXF0d6ejozZszg5Zdf5pVXXsHe3p6wsDDA5oUqpu033nhD2kUtFou0jBoMBqKjo0lPT5dwVafTYW9vT3t7+12MSLGxscLic+LECZKTbRI/3WUcVEoBbBocyjMcNWoUf/rTn6ioqPjHqOf/Gdbe3i4aCeoCwbeV1cbGRhoaGgSPNGrUKCZPnsyBAweYMGECZWVlvPTSS8KsDN8+8H5+fgQEBHD48GG+/PJLZs6ciclkkh7C75pOpxNaIOVGqwdH3awqvFEUVb/61a9EYGbKlClYLBYCAwPR6/XExMQAttAgPDwcvV7PuXPnaGhooL29HRcXF7y8vIQ+XIXayvP7LmuzTqcjOTlZGvRVL6OqhgNSJczPz8fd3Z3t27cTGxsrzNALFizg2LFjlJaWsmnTJmJjY1m5cqWEziosLSws5PXXbRvmY489RkNDAzExMWRnZxMeHi5hivpTQOzXXnuNQ4cOCdW7Ep1WZJWqpzU0NJSysjKefvppYX/28/OTItPevXuJjIwUjGFZWRmNjY14enoSHBwsVOtms/muivrw4cPR6/XEx8cD3EX2aTQa2bVrF6NGjRJqKIUAuHXrFj4+PsyaNUt6qbvn4d544w3AFrIpMlClw6I6D9zc3Dh27BgxMTFMmjSJrKws9Ho9gYGBQv3k6+srD7ybmxt5eXmyyYWEhAinnPJkulcnFYFHSkqKLHpq8VS4yMOHDwvOUW16yp5//nnp8/Xx8SEgIEAqsAp4rnJnc+fOxWg0kpGRwYIFC2RDHT9+PEOHDpXn6P7772f8+PFkZ2eTlpbG6tWriY2NpaGhgc8++0ycCPWbZrOZIUOGyMJnb28vkgCq71ylpLZv3467u7uE/nFxcezbt0+KdYqua9asWTQ1NeHg4EB+fr7o4vyQ9QqP74EHHrDu2bMHs9ksWp0ZGRmyO6rFS1GJqwZp5SV0h04oGIYKibOzsyXnFhwcTFxcHPHx8TQ1NXH69Om7dg/lUSkeN1UsUFAQlas6fvy4LI4hISGkpKSQm5vL8uXLBdy6evVqYmJiOH36NEajkdGjR3P58mXmz59Pdna28MepUj0gN6SirAL+BtCsdnez2czUqVOJioritddew9fXl1deeYWNGzcSGhpKSUkJAElJScKY3N7eTmRkJIsXL6a4uJiEhAQOHjxIfHw8er0eo9HIO++8w/nz57G3t5eclPp/0tLSxBNSRRUFhF66dCkJCQlCmrl27Vph0bVYLCIPqXJPykuIjo7Gzc2NHTt2CHMw2CAwADt27BDRHgW9ABv4W0lHKuiDygNu376drKwsAcX6+fkxdOhQcnNzKSwsJCoqiuPHj6PT6UhJSWHevHkUFRUJAPu1116jo6ODlJQU2VSjo6MxGo2EhYXJGNRY9+3bh8FgYNKkSeTm5orX210y4X+yjo4OTCaTKPXpdDrRllBEDGCD8uzdu1fux6qqKpEFjYiIkHtIkW2o740bNw5fX1/pV1a57u5tcsrjbWho4P7778fBwYF58+ZhMBh47bXX7tKBVpvOwoULmTVrFo2NjWzevJm0tDTxzlUuXq/Xk5SUJAwx6p565plnxINTnJpK/3jw4MESEQwePFhyfOoZVflSPz8/4VRUAk8qr2k0Gvnkk08oKSnpvTm+NWvW/MZkMvHRRx+xf/9+/P39uXnzJnV1dTg5OfHMM89gMBgwm838/Oc/l4brI0eOcPPmTQwGA5999hnt7e088cQTHDhwgKlTpwKQnZ0t4du6deu4dOkSt2/fFqCpAjUDwvunLpIiSujs7KSxsZH+/fsTGRmJpmnCuBsUFMSUKVPw8/PjzJkz7N+/n6VLl5KcnExJSQkjRoxg5syZzJgxg379+hEWFsaYMWOora3F3d0de3t7pk2bJtXAsrIyPDw8aGxs/BtKLTs7O9ra2ujo6ODQoUPs2bOHuro6Nm/ezL59+8jJyWHRokWcPHkSX19fdu3aRXR0NB9//DHl5eWMHDmStWvX8sUXX0jvscFgICkpicLCQp5++ml++9vfEhERIYlje3t7XFxcmDRpEkePHiU1NZVXXnkFZ2dnwEZQmZyczPLly9E0jVmzZlFfX099fb1AEB588EH2798vMKCgoCBpozIYDNKqdevWLc6fP8/48eOFazAwMJDS0lKsViu+vr4UFBSg0+koKSkRsHtDQwMVFRWMHDmSkydPsmTJEn7+85+TkZHBm2++ybvvvsvrr79OcXExkyZN4s0336SlpYWDBw8KhdHnn3/OlClTiIyM5OzZswwfPhxfX18GDx7MwIEDmThxojD6KMSAihrGjBnD/fffz759+/j8889l06moqJA2s+6mYCnK+vXrR319PXV1dfj7+zN69Ghqamqws7OTdjBfX1/69etHQECA8E4qT/LBBx/E39+f4cOHM3HiRDw9PQkJCeHGjRuMHDmSK1euoGkaP/vZz9Dr9ZSUlEgBydnZmebmZjo7O6mrq+POnTvs3r2b+vp6WlpaSE5ORtM0qqqqaG1tlXY7o9HI7du3SUtL49ChQ2zbto333nuPefPmERYWRnNzM2VlZURGRmIymaivrxf4kp2dnfQJDx48mMDAQCHm+MlPfsLVq1cZM2aMjNHV1ZXr169jNpuFs9DDw0Py6yo3qog/XFxcaGtro7y8vHfn+B5++GHrwoULmTJlCnv27BF3WIFVc3JySE9PZ+XKlTQ2NkqeQ9GJd9eWiIiIYObMmezbt0/CL71eT15eHnPmzCE+Pl7YiJUnlZeXJyGF8viAu/QdwBaiLFq0iJkzZ5KWlsaOHTtEshJsje7/9V//BcCbb77JwoUL8fHxIT8/n/z8fN566y3xTMHmKWzYsIFNmzYBSGW6e0VbkRd0H5d64FTu083NjaioKGJiYqQaWlFRwZEjRzh9+rSEDVlZWeKVqPDGYrGwbt06li1bxsKFC6UjYcmSJUJRNHnyZBF5/+qrr1i6dKlQASUkJEjldseOHRQVFZGQkCDexJo1a1iwYAERERFCtw62cFEtenq9ntTUVN566y0MBoNID7q5uTF58mSmT58uG1lDQ4MAtpUCnp+fH9nZ2bzwwguYTCZhU1b5qDVr1kjeSYW7KjXg4+ODi4sLHR0dd/Vyf9cSE21S0SrE0ulsouK7du3C1dVV6NFdXV0l16m0LRSkSZESKMp5hT6ora0VsSAVRagcXXh4uFRSASECUF6aYtn5IautrZXcnUJAWCw2+VIl2q24/BS4/8CBAyQmJgpNvZKJVASxo0aNQq/Xc/r0aX71q1+h0+kkn6py4t0RBSEhISIG352OvruUpiJCUHA2FQWpMHjw4MEEBwcLZEalRpRiXHfVQ5WHHzhwIPX19b2Xev7hhx+2njlzhoqKCrZu3XpXSV+5w4oKSiVLFewlICCA+Ph4EfhRifXMzEzpRAgODmbChAk8/vjjzJ49m9LSUmJiYkSBTCHAu4eUin5d3WBKeyM/P599+/ZRWFjIhg0bBOqiqrcmk4ny8nKuXbvG2LFjpTijGFgcHBzIycmRMEjd9FevXpVKneqpVbq83dllwHbz+/n5yW7n4ODAqFGj7lKnz8rKIi8vj5deeokLFy7g5+eHi4sL+/btk+8onYPDhw8zY8YM0tPTmT17NrNmzRLpwMzMTDIyMvD398dkMjFlyhTR7lUWFRXFwoULKS4uZseOHTg4OEgxQ4VpKrxSxRElgKMU31RnQ2lpqehbhIeHS9I9Ly9PoCmtra3SN+zm5ibQoPHjxxMaGipKYwqOohZ6BQJXBSa1QIWEhJCTkyObS1VVlUg3Go1Gxo4dS1ZWFgDvvPOOLBJK59bNzU2o6SMiIhgyZAilpaVCCWUymUTDxGQysWzZMrZs2YLRaJS8nApZu1/n0tJSAgICWLRo0V3qbGqs3b3mkJCQ71Uvg28VzFT/sGqnUwtoeHg4CQkJ0mdsMBikY8nNzU3uk+7pHUV5r/LGCqqkcnWAbE7dcapKskGFtOp8zWazcFoqUSclZRoWFib3T0NDg0C31POqtIoVFlE9Lx988MEPLny9ItR94403fhMcHExwcDDTp0/n2rVrXL16ldGjRwuM48UXX2Ts2LEUFRXx1ltvUVRUhIeHB/PmzWPSpElkZmby6quvArY8woMPPkhAQACVlZV8/vnn0naVmpqKk5MTBoNBaO1VP69iQgEbqFp1ZIDt5ikvL6etrY0TJ04QGBgoAOZBgwZRVlbG8OHD8ff359y5cyIZWFVVhZOTEw8//LB0UHz88cf86U9/YuvWrRQUFPC73/2OuXPn8stf/pLp06eTnJxMXV2dlPIB+Vd1LCg2ErPZzEMPPUR5eTn//d//zfz583FwcJCE87Zt2zh16hQFBQU88sgj3Llzh71792IwGPjqq69kY7G3t2fMmDGcP39eYAd/+MMfBMrj5OTEhg0b+OSTT/D39+fPf/4zWVlZPPXUU+Tm5vLRRx/h7+/PlStXiImJoaioiPDwcHJzc4X1xsfHh+vXr0ueqaamBjc3N6Kjoxk5ciSaphEUFERBQYG0OZnNZqGuV4I9vr6+9O/fn6qqKm7evMmwYcO4ePEi4eHhODs7S+7X1dWV4uJinJ2dCQoKws3NjQ8//JCCggKee+45Tp06xf79+/nrX//KyZMnSUlJ4dKlS5SVlZGSksKXX37Jvn37+Mtf/sLQoUNlPE8//TTr1q2jX79+XL16VUR7rl27JuSf4eHhhIWFcfr0afLz82lpaaGlpYXOzk4mTpzI0aNHcXV1xdnZmbNnz0q/rpqrW7duUV9fT2VlJbm5ucL4PW3aNNra2mhvbyc/P5+ysjI+/vhjsrOzBdj95ZdfMnToULy8vNi1axfp6el88skn0tkRGhqKt7c3fn5+eHp6SiFw4cKFwq04ffp0BgwYIOwvSpahtLQUZ2dn5s2bJxx8YCtQqrxiZ2cnAwYMkH53sKkiBgYGkpOTg5OTE3q9nv79++Pk5ISvry+DBg2irq6Ozs5ORo4cSWtrq0CeoqKiSEpKorm5mbCwMFm8b968KV1N6hmtq6uTML+oqOgHGZh7xcKXlJT0m7lz5+Lj40NaWhrPPPMMR44c4cMPP+TBBx+kpaWFoqIiYelNTU3FwcGBmzdv4uvry0MPPcS5c+fw9vbG2dmZkSNH4uLiQkVFBeHh4Zw9e5annnqKa9euMXLkSMaNGycaEY6OjhQXFwPIoqcmUqfTCQ28ct87OjoYN24cJ0+exGw2s3nzZubPn09+fj63b9+ms7OTwMBARo4cyVNPPcWRI0cYMmSINIibTCZef/11cnJy5EKpRWvEiBHU1dVJN4C3tzfKI1c3iSIycHJywsnJibq6Oh5//HE8PT1Zv349q1at4sknnyQrK4vFixfT0dHBsGHDWLJkCUeOHBFK+kuXLrF//365Brt37+aLL74QXY3Ozk70ej1z5sxh3rx5HD58mGvXruHo6Mhjjz3G6tWrOXToEE1NTRw6dIilS5fy9ttvM3PmTNLT0/H09GT//v0COlWhUnNzM46Ojjz33HNcvHiRzz//XLwWZ2dnaQ0D5KHR6/V0dnYKGWhhYSFhYWHikXh7ezNlyhSCgoIYPnw4Q4YMIS0tjdu3b3Ps2DFmzJjBpUuXeP/997FYLPz6178mPj6er7/+moaGBu7cuSPeQ2dnJ/369SM/P5+Ojg5+9rOfUVNTw/Xr1zl58qSo+O3du5fbt29jMBhwcnKipqZGcmVVVVXCNfjCCy8wfPhwTCYTnZ2dPPLII7S0tFBeXk5lZSW+vr6St1LkEXZ2dkyYMAEvLy+GDRsmIf2gQYPYuXMnBQUFgilV9E2VlZX069ePmpoa+vfvT2pqKgUFBQQGBnLixAns7Ow4d+4c58+fp7i4WIDRhYWFtLS04Orq+jdIhyFDhjBkyBBCQkJ48sknCQsLkz7hgoICMjMzKSsrw8HBQcgsFCSrubkZf39/uebt7e2MHDmS8PBwMjMzefjhh7lz5w41NTU4Ojry6aef0tHRgZeXl3Acjh49mhUrVrBr1y7hvszOzqazsxN7e3shLB46dCgdHR24u7sLY7iLiwulpaW8+OKLvZekoK2tjaqqKrZt28bx48dJTk5m8ODB7Ny5E4vFwsGDB6XEr1x2BU9YvHgxS5cuxWQy0dbWRkZGBhEREcTFxUmxQBF+btmyRR5Ci8XCpk2bJJ+kwMPdoQPKZVaQEvW7iuK9oaGBmTNnEhkZSUxMDIGBgSxdulRIGlU4ouiOQkNDxRtU6HL4FvG/ZcsWKSp0p91R2CYV5ut032oFh4aGSj7EZDKxc+dOZs+ezbhx41izZo3kZ1xcXCTMqK6uJikpidzcXLKzs8nMzARs3qQKM5WcocIoqnHodDoWL17MoUOHpD1v5cqV7N27F6PRSF5eHp999hl+fn4icB4REUF5ebmo6E2dOpWqqipcXV1FklAx/Cr9DiX3CTYGaoX5U/AKnU5HSEgIGRkZcu0XLVqEi4sLs2fPJiIiguTkZAmJg4KCMBqNsqiuWrWK5ORkwfcpTVsVSql8l5L5VISkivUjODiYpKQkFi1aRE1NDZ6ennep4Dk6OnL8+HFhBFY07wCRkZHk5eUJfX/3LguwaekqWUVAMJxKQrR7J466JipEVNhAlcY5ePAgeXl5otanHAeFedPpdCKJOXfu3L+pRHcXmQ8MDARg+PDhQjqRkZEh10gpFqoqrZrPxsZG7O3tyczMxMfHh+joaC5fvnxXq6fSzFUQFyWlsHHjRvR6PRkZGUItr4gd1O9GRUWJZnBhYaEIwKv///usV+T4NE1rBK709Dj+F+YFVPf0IP5B6xt7z9m9PP57YezDrFar/vs+6BUeH3DFarU+3NOD+EdN07Qz9+r4+8bec3Yvj/9eHjv0EnaWPuuzPuuzf6b1LXx91md99qOz3rLw7ezpAfwv7V4ef9/Ye87u5fHfy2PvHcWNPuuzPuuzf6b1Fo+vz/qsz/rsn2Z9C1+f9Vmf/eisxxc+TdN+qmnaFU3Trmqatqqnx/Nd0zTNV9O0U5qmmTRNu6xp2itdxwdpmnZc07Rvuv716DquaZq2tet8LmiaFtazZwCapvXXNC1P07TUrvcjNE3L6Rrjfk3THLqO67reX+36fHhPjrtrTAM1TUvWNO1rTdPyNU2bcK/MvaZpv+q6Zy5pmvYXTdMce/Pca5qWoGnaLU3TLnU79nfPtaZpC7u+/42maQu/77d63KxWa4/9Af2BQsAPcADOA8aeHNP3jNEbCOt67QoUAEZgI7Cq6/gqYEPX65nAUUADwoGcXnAO/wEkAald7/8KPN31egewtOv1C8COrtdPA/t7wdgTgV92vXYABt4Lcw/4ANeAAd3m/Be9ee6ByUAYcKnbsb9rroFBQFHXvx5drz16+j76m3Pt0R+HCUB6t/f/CfxnT0/K/2XMHwER2DpNvLuOeWMDYQO8Cyzo9n3tBHV4AAAC2klEQVT5Xg+N1wCcAKYBqV03ajVg991rAKQDE7pe23V9T+vBsbt3LR7ad473+rnvWvhKuxYAu665n9Hb5x4Y/p2F7++aa2AB8G6343d9r7f89XSoq24OZWVdx3qldYUfoUAOMMRqtd7o+qgSGNL1ured0xZgBXCn670nUG+1Wju63ncfn4y96/OGru/3lI0AqoA9XaH6nzRNc+YemHur1VoObAJKgBvY5vIs987cK/t757rXXIP/yXp64btnTNM0F+AgsMxqtZq7f2a1bW29DhekaVoUcMtqtZ7t6bH8g2aHLfTabrVaQ4FmbOGWWC+eew/gSWyL91DAGfhpjw7qf2m9da7/Eevpha8c8O323tB1rFeZpmn22Ba9vVar9YOuwzc1TfPu+twbUFQQvemcJgKzNU0rBvZhC3f/AAzUNE31aXcfn4y963N3oIaeszKgzGq1KtbTZGwL4b0w99OBa1artcpqtbYDH2C7HvfK3Cv7e+e6N12DH7SeXvhygQe6Kl0O2JK6h3t4THeZpmkasBvIt1qtv+/20WFAVawWYsv9qePPdlW9woGGbqHCP9WsVut/Wq1Wg9VqHY5tbk9ardYY4BQwr+tr3x27Oqd5Xd/vsR3earVWAqWapgV2HXocMHEPzD22EDdc0zSnrntIjf2emPtu9vfOdToQqWmaR5fXG9l1rHdZTycZsVWHCrBVd1f39Hi+Z3yTsLn3F4BzXX8zseVfTgDfAJ8Ag7q+rwF/7Dqfi8DDPX0OXeOayrdVXT/gS+AqcADQdR137Hp/tetzv14w7hDgTNf8f4itUnhPzD3wOvA1cAl4D9D15rkH/oItH9mOzdt+7h+ZayC26zyuAot6+h76vr++lrU+67M++9FZT4e6fdZnfdZn/3TrW/j6rM/67EdnfQtfn/VZn/3orG/h67M+67MfnfUtfH3WZ332o7O+ha/P+qzPfnTWt/D1WZ/12Y/O/g9j9a+R5X0npgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(im, cmap=plt.cm.gray)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "allen",
+   "language": "python",
+   "name": "allen"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ GENERAL_REQUIRES = ['numpy', 'scipy', 'matplotlib', 'pandas', 'requests',
 
 EXTRAS_REQUIRES = {
     'docs': ['sphinx', 'sphinx_rtd_theme', 'pygments-enaml'],
+    'nwb': ['allensdk'],
 }
 
 setup(


### PR DESCRIPTION
Adds `Recording.from_nwb()` class method to instantiate a `Recording` object from NWB files. Currently supports neuropixel ecephys format, where a `Recording` is composed of experiment metadata along with a single `PointProcess` signal of the spike times, as well as an epochs dataframe and metadata about each unit. Also includes demo notebook, with details on obtaining stimulus images.

Writing NWB files is much more complicated, so was moved to a new issue (#167) and will be a separate PR.

Resolves #165. 