### PR TITLE
fixing bug(s) in epoch masking pipeline.

### DIFF
--- a/nems/epoch.py
+++ b/nems/epoch.py
@@ -262,7 +262,6 @@ def epoch_intersection(a, b, precision=6):
 
     lb, ub = a.pop()
     lb_b, ub_b = b.pop()
-
     while True:
         if lb >= ub_b:
             #           [ a ]
@@ -317,7 +316,7 @@ def epoch_intersection(a, b, precision=6):
                 lb, ub = a.pop()
             except IndexError:
                 break
-        elif (lb > lb_b) and (lb <= ub_b):
+        elif (lb > lb_b) and (ub <= ub_b):
             #   [  a    ]
             # [       b     ]
             # Current epoch in a is fully contained in b
@@ -326,7 +325,7 @@ def epoch_intersection(a, b, precision=6):
                 lb, ub = a.pop()
             except IndexError:
                 break
-        elif (ub > lb_b) and (ub < ub_b) and (lb > ub_b):
+        elif (lb > lb_b) and (ub > ub_b):
             #   [  a    ]
             # [ b    ]
             intersection.append((lb, ub_b))


### PR DESCRIPTION
1) `epoch.epoch_intersection` had bug(s) in boolean logic.
2) `signal.get_epoch_indices` was saving timestamps not contained in signal segments. For example, if `EPOCH_NAME` went from 3 to 10 and the signal segment went from 2 to 5, the function was saving the entire epoch (3 to 10), rather than truncating at the end of the segment (3 to 5).
3) `signal.get_epoch_indices` wasn't saving epoch names that completely contained masked segments. For example, if `EPOCH_NAME` went from 3 to 10 and masked segment went from 5 to 7, that epoch name would get dropped. Now, it will get truncated, but kept in epoch df.