### PR TITLE
awctomlinson/epoch-speedup

### DIFF
--- a/nems/signal.py
+++ b/nems/signal.py
@@ -1613,10 +1613,12 @@ class RasterizedSignal(SignalBase):
         '''
         # TODO: Update this to work with a mapping of key -> Nx2 epoch
         # structure as well.
-        new_data = np.full(self.shape, np.nan, dtype = self._data.dtype)
-        for epoch_name in list_of_epoch_names:
-            for (lb, ub) in self.get_epoch_indices(epoch_name):
-                new_data[:, lb:ub] = self._data[:, lb:ub]
+        new_data = np.full(self.shape, np.nan, dtype=self._data.dtype)
+
+        mask = self.epochs['name'].isin(list_of_epoch_names)
+        for (lb, ub) in self.get_epoch_indices(mask):
+            new_data[:, lb:ub] = self._data[:, lb:ub]
+
         if np.all(np.isnan(new_data)):
             warnings.warn("No matched occurrences for epochs: \n{}\n"
                                  "Returned signal will be only NaN."


### PR DESCRIPTION
Several changes to various signal and epoch functions to use vectorized version of `get_epoch_indices` instead of looping through epochs. 

Changes to `average_away_epoch_occurrences` to speed up large loops.

Further speedups in this area will be difficult, but I'm still thinking on it.

Tested with:
```
batch = 308
cell_id = 'AMT003c-19-1'
```
Timing:
```
%%timeit
train, test = rec.split_using_epoch_occurrence_counts('^STIM')
train = average_away_epoch_occurrences(train)
test = average_away_epoch_occurrences(test)
```
Results:
```
Old: 16.5 s ± 1.54 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
New: 4.88 s ± 408 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
~3.4x improvement!
```