### PR TITLE
Updated xforms.load_recordings and ld loader keyword

### DIFF
--- a/nems/plugins/default_loaders.py
+++ b/nems/plugins/default_loaders.py
@@ -1,4 +1,4 @@
-def ld(loadkey, recording_uri=None, cellid=None):
+def ld(loadkey, recording_uri=None, recording_uri_list=None, cellid=None):
     '''
     Default loader xfspec. Loads the recording and (optionally) specifies
     input_name and output_name context variables that tell, respectively, the
@@ -18,8 +18,15 @@ def ld(loadkey, recording_uri=None, cellid=None):
     options = loadkey.split('.')[1:]
 
     d = {}
+
+    # TODO: really should only have one argument or the other, but currently some code uses the first
+    # version while other code uses the second version. So until that gets resolved, need to accept
+    # both versions as kwargs, otherwise the information will not be passed from the registry.
     if recording_uri is not None:
         d['recording_uri_list'] = [recording_uri]
+    elif recording_uri_list is not None:
+        d['recording_uri_list'] = recording_uri_list
+
     d['normalize'] = False
     #if cellid is not None:
     #    d['cellid'] = cellid

--- a/nems/xform_helper.py
+++ b/nems/xform_helper.py
@@ -101,7 +101,8 @@ def generate_xforms_spec(recording_uri=None, modelname=None, meta={},
             xforms_init_context['recording_uri_list'] = recording_uri
         else:
             xforms_init_context['recording_uri_list'] = [recording_uri]
-    xforms_init_context.update(xforms_kwargs)
+    if xforms_kwargs is not None:
+        xforms_init_context.update(xforms_kwargs)
     xforms_lib.kwargs = xforms_init_context.copy()
     xfspec.append(['nems.xforms.init_context', xforms_init_context])
 


### PR DESCRIPTION
ld now accepts recording_uri_list as a keyword argument.
This is redunant with the recording_uri keyword argument.
However, since some code references the former while other
code references the latter, both need to be present as keyword
arguments. Otherwise, the Registry object will not pass along
that information. As a result, recording_uri_list was not being
saved with the xfspec which caused errors when trying to load
saved analyses.

load_recordings now accepts two new cellid formats:
1) siteids: If no hyphen is present in cellid, it will be
interpreted as a siteid. In that case, all channels that contain
the siteid will be extracted.
2) None:  if cellid=None, all channels will be extracted.

Also fixed generate_stim_from_epochs so that it will not cause
an error if no matches are found for epoch_regex. Previously
this effectively hardcoded a requirement that all recordings contain
"TRIAL" epochs when using load_recordings.