### PR TITLE
Jacob pop updates

### DIFF
--- a/nems/initializers.py
+++ b/nems/initializers.py
@@ -96,7 +96,7 @@ def from_keywords(keyword_string, registry=None, rec=None, meta={},
             log.info("kw: dynamically subbing %s with %s", kw_old, kw)
 
         other_xr = re.findall("[x][0-9]+[R]", kw)
-        if bool(other_xR):
+        if bool(other_xr):
             R = rec[output_name].nchans
             kw_old = kw
             kw = kw.replace("xR", "x{}".format(int(other_xr[0])*R))

--- a/nems/initializers.py
+++ b/nems/initializers.py
@@ -95,12 +95,12 @@ def from_keywords(keyword_string, registry=None, rec=None, meta={},
             kw = kw.replace("xR", "x{}".format(R))
             log.info("kw: dynamically subbing %s with %s", kw_old, kw)
 
-        other_xr = re.findall("[x][0-9]+[R]", kw)
+        other_xr = re.findall(r"[x\.]?[0-9]+[R]", kw)
         if bool(other_xr):
             R = rec[output_name].nchans
             kw_old = kw
             digits = int(re.findall("[0-9]+", other_xr[0])[0])
-            kw = kw.replace("x{}R".format(digits), "x{}".format(digits*R))
+            kw = kw.replace("{}R".format(digits), "{}".format(digits*R))
             log.info("kw: dynamically subbing %s with %s", kw_old, kw)
 
         # if (("x2R" in kw) or (".2R" in kw)) and (rec is not None):

--- a/nems/initializers.py
+++ b/nems/initializers.py
@@ -99,7 +99,8 @@ def from_keywords(keyword_string, registry=None, rec=None, meta={},
         if bool(other_xr):
             R = rec[output_name].nchans
             kw_old = kw
-            kw = kw.replace("xR", "x{}".format(int(other_xr[0])*R))
+            digits = int(re.findall("[0-9]+", other_xr[0])[0])
+            kw = kw.replace("x{}R".format(digits), "x{}".format(digits*R))
             log.info("kw: dynamically subbing %s with %s", kw_old, kw)
 
         # if (("x2R" in kw) or (".2R" in kw)) and (rec is not None):

--- a/nems/initializers.py
+++ b/nems/initializers.py
@@ -1,8 +1,10 @@
 import logging
-
+import re
 import copy
-import numpy as np
 import os
+
+import numpy as np
+
 from nems.plugins import default_keywords
 from nems.utils import find_module, get_default_savepath
 from nems.analysis.api import fit_basic
@@ -93,23 +95,30 @@ def from_keywords(keyword_string, registry=None, rec=None, meta={},
             kw = kw.replace("xR", "x{}".format(R))
             log.info("kw: dynamically subbing %s with %s", kw_old, kw)
 
-        if (("x2R" in kw) or (".2R" in kw)) and (rec is not None):
+        other_xr = re.findall("[x][0-9]+[R]", kw)
+        if bool(other_xR):
             R = rec[output_name].nchans
             kw_old = kw
-            kw = kw.replace("2R", "{}".format(2*R))
+            kw = kw.replace("xR", "x{}".format(int(other_xr[0])*R))
             log.info("kw: dynamically subbing %s with %s", kw_old, kw)
 
-        if (("x3R" in kw) or (".3R" in kw)) and (rec is not None):
-            R = rec[output_name].nchans
-            kw_old = kw
-            kw = kw.replace("3R", "{}".format(3*R))
-            log.info("kw: dynamically subbing %s with %s", kw_old, kw)
-
-        if (("x4R" in kw) or (".4R" in kw)) and (rec is not None):
-            R = rec[output_name].nchans
-            kw_old = kw
-            kw = kw.replace("4R", "{}".format(4*R))
-            log.info("kw: dynamically subbing %s with %s", kw_old, kw)
+        # if (("x2R" in kw) or (".2R" in kw)) and (rec is not None):
+        #     R = rec[output_name].nchans
+        #     kw_old = kw
+        #     kw = kw.replace("2R", "{}".format(2*R))
+        #     log.info("kw: dynamically subbing %s with %s", kw_old, kw)
+        #
+        # if (("x3R" in kw) or (".3R" in kw)) and (rec is not None):
+        #     R = rec[output_name].nchans
+        #     kw_old = kw
+        #     kw = kw.replace("3R", "{}".format(3*R))
+        #     log.info("kw: dynamically subbing %s with %s", kw_old, kw)
+        #
+        # if (("x4R" in kw) or (".4R" in kw)) and (rec is not None):
+        #     R = rec[output_name].nchans
+        #     kw_old = kw
+        #     kw = kw.replace("4R", "{}".format(4*R))
+        #     log.info("kw: dynamically subbing %s with %s", kw_old, kw)
 
         log.info('kw: %s', kw)
 


### PR DESCRIPTION
made the R substitution code in init_from_keywords work for arbitrary rank, b/c I was testing some larger LN/STP models.