### PR TITLE
Jacob all sites

### DIFF
--- a/nems/utils.py
+++ b/nems/utils.py
@@ -390,8 +390,6 @@ def get_default_savepath(modelspec):
     else:
         results_dir = get_setting('NEMS_RESULTS_DIR')
 
-    import pdb; pdb.set_trace()
-
     batch = modelspec.meta.get('batch', 0)
     exptid = modelspec.meta.get('exptid', 'DATA')
     siteid = modelspec.meta.get('siteid', exptid)

--- a/nems/utils.py
+++ b/nems/utils.py
@@ -389,6 +389,9 @@ def get_default_savepath(modelspec):
                       str(get_setting('NEMS_BAPHY_API_PORT')) + '/results'
     else:
         results_dir = get_setting('NEMS_RESULTS_DIR')
+
+    import pdb; pdb.set_trace()
+
     batch = modelspec.meta.get('batch', 0)
     exptid = modelspec.meta.get('exptid', 'DATA')
     siteid = modelspec.meta.get('siteid', exptid)
@@ -396,7 +399,10 @@ def get_default_savepath(modelspec):
     cellids = modelspec.meta.get('cellids', siteid)
 
     if (siteid == 'DATA') and (type(cellids) is list) and len(cellids) > 1:
-        siteid = cellids[0].split("-")[0]
+        if cellid == 'none':
+            siteid = 'none'  # special siteid that uses all sites in a single recording
+        else:
+            siteid = cellids[0].split("-")[0]
         destination = os.path.join(results_dir, str(batch), siteid,
                                    modelspec.get_longname())
     else:

--- a/nems/xform_helper.py
+++ b/nems/xform_helper.py
@@ -207,8 +207,10 @@ def fit_model_xform(cellid, batch, modelname, autoPlot=True, saveInDB=False,
     cellids = modelspec.meta.get('cellids', [])
 
     if (type(cellids) is list) and len(cellids) > 1:
-
-        cell_name = cellids[0].split("-")[0]
+        if cellid == 'none':
+            cell_name = 'none'
+        else:
+            cell_name = cellids[0].split("-")[0]
 
     elif type(cellid) is list:
         cell_name = cellid[0].split("-")[0]


### PR DESCRIPTION
Updated functions that generate default model savepaths to cooperate with siteid='none' option for fitting all sites in NAT3 dataset. Previously they were saving to whatever siteid happened to be first in the list even though several siteids were used, which made locating the files confusing.